### PR TITLE
Updates to features/224

### DIFF
--- a/Source/Rio.API/Controllers/AccountController.cs
+++ b/Source/Rio.API/Controllers/AccountController.cs
@@ -333,7 +333,7 @@ You can view parcels associated with this account and the water allocation and u
             mailMessage.IsBodyHtml = true;
             mailMessage.From = SitkaSmtpClientService.GetDefaultEmailFrom();
             SitkaSmtpClientService.AddReplyToEmail(mailMessage);
-            SitkaSmtpClientService.AddAdminsAsBccRecipientsToEmail(mailMessage, EFModels.Entities.User.ListByRole(_dbContext, RoleEnum.Admin));
+            SitkaSmtpClientService.AddBccRecipientsToEmail(mailMessage, EFModels.Entities.User.EmailAddressesForAdminsThatReceiveSupportEmails(_dbContext));
             smtpClient.Send(mailMessage);
         }
 

--- a/Source/Rio.API/Controllers/AccountController.cs
+++ b/Source/Rio.API/Controllers/AccountController.cs
@@ -333,7 +333,7 @@ You can view parcels associated with this account and the water allocation and u
             mailMessage.IsBodyHtml = true;
             mailMessage.From = SitkaSmtpClientService.GetDefaultEmailFrom();
             SitkaSmtpClientService.AddReplyToEmail(mailMessage);
-            SitkaSmtpClientService.AddBccRecipientsToEmail(mailMessage, EFModels.Entities.User.EmailAddressesForAdminsThatReceiveSupportEmails(_dbContext));
+            SitkaSmtpClientService.AddBccRecipientsToEmail(mailMessage, EFModels.Entities.User.GetEmailAddressesForAdminsThatReceiveSupportEmails(_dbContext));
             smtpClient.Send(mailMessage);
         }
 

--- a/Source/Rio.API/Controllers/OfferController.cs
+++ b/Source/Rio.API/Controllers/OfferController.cs
@@ -127,7 +127,7 @@ namespace Rio.API.Controllers
             mailMessage.IsBodyHtml = true;
             mailMessage.From = SitkaSmtpClientService.GetDefaultEmailFrom();
             SitkaSmtpClientService.AddReplyToEmail(mailMessage);
-            SitkaSmtpClientService.AddBccRecipientsToEmail(mailMessage, EFModels.Entities.User.EmailAddressesForAdminsThatReceiveSupportEmails(_dbContext));
+            SitkaSmtpClientService.AddBccRecipientsToEmail(mailMessage, EFModels.Entities.User.GetEmailAddressesForAdminsThatReceiveSupportEmails(_dbContext));
             smtpClient.Send(mailMessage);
         }
 

--- a/Source/Rio.API/Controllers/OfferController.cs
+++ b/Source/Rio.API/Controllers/OfferController.cs
@@ -127,7 +127,7 @@ namespace Rio.API.Controllers
             mailMessage.IsBodyHtml = true;
             mailMessage.From = SitkaSmtpClientService.GetDefaultEmailFrom();
             SitkaSmtpClientService.AddReplyToEmail(mailMessage);
-            SitkaSmtpClientService.AddAdminsAsBccRecipientsToEmail(mailMessage, EFModels.Entities.User.ListByRole(_dbContext, RoleEnum.Admin));
+            SitkaSmtpClientService.AddBccRecipientsToEmail(mailMessage, EFModels.Entities.User.EmailAddressesForAdminsThatReceiveSupportEmails(_dbContext));
             smtpClient.Send(mailMessage);
         }
 

--- a/Source/Rio.API/Controllers/UserController.cs
+++ b/Source/Rio.API/Controllers/UserController.cs
@@ -334,17 +334,6 @@ As an administrator of the Water Accounting Platform, you can assign them a role
             mailMessage.IsBodyHtml = true;
             mailMessage.From = SitkaSmtpClientService.GetDefaultEmailFrom();
             SitkaSmtpClientService.AddReplyToEmail(mailMessage);
-            //if (typeOfCCAdminsToReceive.ToLower() == "bcc")
-            //{
-            //    SitkaSmtpClientService.AddAdminsAsBccRecipientsToEmail(mailMessage,
-            //        EFModels.Entities.User.AdminsThatReceiveSupportEmails(_dbContext));
-            //}
-            //else if (typeOfCCAdminsToReceive.ToLower() == "cc")
-            //{
-            //    SitkaSmtpClientService.AddAdminsAsCCRecipientsToEmail(mailMessage,
-            //        EFModels.Entities.User.AdminsThatReceiveSupportEmails(_dbContext));
-            //}
-
             smtpClient.Send(mailMessage);
         }
     }

--- a/Source/Rio.API/Controllers/UserController.cs
+++ b/Source/Rio.API/Controllers/UserController.cs
@@ -119,11 +119,8 @@ namespace Rio.API.Controllers
                 userUpsertDto.UserGuid);
 
             var smtpClient = HttpContext.RequestServices.GetRequiredService<SitkaSmtpClientService>();
-            var mailMessages = GenerateUserCreatedEmail(_rioConfiguration.RIO_WEB_URL, user, _dbContext);
-            foreach (var mailMessage in mailMessages)
-            {
-                SendEmailMessage(smtpClient, mailMessage, false);
-            }
+            var mailMessage = GenerateUserCreatedEmail(_rioConfiguration.RIO_WEB_URL, user, _dbContext);
+            SendEmailMessage(smtpClient, mailMessage, "cc");
 
             return Ok(user);
         }
@@ -262,7 +259,7 @@ namespace Rio.API.Controllers
             var mailMessages = GenerateAddedAccountsEmail(_rioConfiguration.RIO_WEB_URL, updatedUserDto, addedAccounts);
             foreach (var mailMessage in mailMessages)
             {
-                SendEmailMessage(smtpClient, mailMessage, true);
+                SendEmailMessage(smtpClient, mailMessage, "bcc");
             }
 
             return Ok(updatedUserDto);
@@ -311,40 +308,39 @@ namespace Rio.API.Controllers
             return mailMessages;
         }
 
-        private static List<MailMessage> GenerateUserCreatedEmail(string rioUrl, UserDto user, RioDbContext dbContext)
+        private static MailMessage GenerateUserCreatedEmail(string rioUrl, UserDto user, RioDbContext dbContext)
         {
-            var mailMessages = new List<MailMessage>();
             var messageBody = $@"A new user has signed up to the Rosedale-Rio Bravo Water Accounting Platform: <br/><br/>
  {user.FullName} ({user.Email}) <br/><br/>
 As an administrator of the Water Accounting Platform, you can assign them a role and associate them with a Billing Account by following <a href='{rioUrl}/users/{user.UserID}'>this link</a>. <br/><br/>
-{SitkaSmtpClientService.GetDefaultEmailSignature()}";
+{SitkaSmtpClientService.GetSupportNotificationEmailSignature()}";
 
-            var administrators = EFModels.Entities.User.AdminsThatReceiveSupportEmails(dbContext);
-
-             var mailTos = administrators;
-            foreach (var mailTo in mailTos)
+            var mailMessage = new MailMessage
             {
-                var mailMessage = new MailMessage
-                {
-                    Subject = $"New User in Rosedale-Rio Bravo Water Accounting Platform",
-                    Body = $"Hello {mailTo.FullName},<br /><br />{messageBody}"
-                };
-                mailMessage.To.Add(new MailAddress(mailTo.Email, mailTo.FullName));
-                mailMessages.Add(mailMessage);
-            }
-            return mailMessages;
+                Subject = $"New User in Rosedale-Rio Bravo Water Accounting Platform",
+                Body = $"Hello,<br /><br />{messageBody}",
+            };
+
+            mailMessage.To.Add(SitkaSmtpClientService.GetDefaultEmailFrom());
+            return mailMessage;
         }
 
-        private void SendEmailMessage(SitkaSmtpClientService smtpClient, MailMessage mailMessage, bool addAdminsAsBccRecipients)
+        private void SendEmailMessage(SitkaSmtpClientService smtpClient, MailMessage mailMessage, string typeOfCCAdminsToReceive = "None")
         {
             mailMessage.IsBodyHtml = true;
             mailMessage.From = SitkaSmtpClientService.GetDefaultEmailFrom();
             SitkaSmtpClientService.AddReplyToEmail(mailMessage);
-            if (addAdminsAsBccRecipients)
+            if (typeOfCCAdminsToReceive.ToLower() == "bcc")
             {
                 SitkaSmtpClientService.AddAdminsAsBccRecipientsToEmail(mailMessage,
                     EFModels.Entities.User.AdminsThatReceiveSupportEmails(_dbContext));
             }
+            else if (typeOfCCAdminsToReceive.ToLower() == "cc")
+            {
+                SitkaSmtpClientService.AddAdminsAsCCRecipientsToEmail(mailMessage,
+                    EFModels.Entities.User.AdminsThatReceiveSupportEmails(_dbContext));
+            }
+
             smtpClient.Send(mailMessage);
         }
     }

--- a/Source/Rio.API/Controllers/UserController.cs
+++ b/Source/Rio.API/Controllers/UserController.cs
@@ -120,7 +120,9 @@ namespace Rio.API.Controllers
 
             var smtpClient = HttpContext.RequestServices.GetRequiredService<SitkaSmtpClientService>();
             var mailMessage = GenerateUserCreatedEmail(_rioConfiguration.RIO_WEB_URL, user, _dbContext);
-            SendEmailMessage(smtpClient, mailMessage, "cc");
+            SitkaSmtpClientService.AddCcRecipientsToEmail(mailMessage,
+                        EFModels.Entities.User.EmailAddressesForAdminsThatReceiveSupportEmails(_dbContext));
+            SendEmailMessage(smtpClient, mailMessage);
 
             return Ok(user);
         }
@@ -259,7 +261,9 @@ namespace Rio.API.Controllers
             var mailMessages = GenerateAddedAccountsEmail(_rioConfiguration.RIO_WEB_URL, updatedUserDto, addedAccounts);
             foreach (var mailMessage in mailMessages)
             {
-                SendEmailMessage(smtpClient, mailMessage, "bcc");
+                SitkaSmtpClientService.AddBccRecipientsToEmail(mailMessage, 
+                    EFModels.Entities.User.EmailAddressesForAdminsThatReceiveSupportEmails(_dbContext));
+                SendEmailMessage(smtpClient, mailMessage);
             }
 
             return Ok(updatedUserDto);
@@ -325,21 +329,21 @@ As an administrator of the Water Accounting Platform, you can assign them a role
             return mailMessage;
         }
 
-        private void SendEmailMessage(SitkaSmtpClientService smtpClient, MailMessage mailMessage, string typeOfCCAdminsToReceive = "None")
+        private void SendEmailMessage(SitkaSmtpClientService smtpClient, MailMessage mailMessage)
         {
             mailMessage.IsBodyHtml = true;
             mailMessage.From = SitkaSmtpClientService.GetDefaultEmailFrom();
             SitkaSmtpClientService.AddReplyToEmail(mailMessage);
-            if (typeOfCCAdminsToReceive.ToLower() == "bcc")
-            {
-                SitkaSmtpClientService.AddAdminsAsBccRecipientsToEmail(mailMessage,
-                    EFModels.Entities.User.AdminsThatReceiveSupportEmails(_dbContext));
-            }
-            else if (typeOfCCAdminsToReceive.ToLower() == "cc")
-            {
-                SitkaSmtpClientService.AddAdminsAsCCRecipientsToEmail(mailMessage,
-                    EFModels.Entities.User.AdminsThatReceiveSupportEmails(_dbContext));
-            }
+            //if (typeOfCCAdminsToReceive.ToLower() == "bcc")
+            //{
+            //    SitkaSmtpClientService.AddAdminsAsBccRecipientsToEmail(mailMessage,
+            //        EFModels.Entities.User.AdminsThatReceiveSupportEmails(_dbContext));
+            //}
+            //else if (typeOfCCAdminsToReceive.ToLower() == "cc")
+            //{
+            //    SitkaSmtpClientService.AddAdminsAsCCRecipientsToEmail(mailMessage,
+            //        EFModels.Entities.User.AdminsThatReceiveSupportEmails(_dbContext));
+            //}
 
             smtpClient.Send(mailMessage);
         }

--- a/Source/Rio.API/Controllers/UserController.cs
+++ b/Source/Rio.API/Controllers/UserController.cs
@@ -121,7 +121,7 @@ namespace Rio.API.Controllers
             var smtpClient = HttpContext.RequestServices.GetRequiredService<SitkaSmtpClientService>();
             var mailMessage = GenerateUserCreatedEmail(_rioConfiguration.RIO_WEB_URL, user, _dbContext);
             SitkaSmtpClientService.AddCcRecipientsToEmail(mailMessage,
-                        EFModels.Entities.User.EmailAddressesForAdminsThatReceiveSupportEmails(_dbContext));
+                        EFModels.Entities.User.GetEmailAddressesForAdminsThatReceiveSupportEmails(_dbContext));
             SendEmailMessage(smtpClient, mailMessage);
 
             return Ok(user);
@@ -262,7 +262,7 @@ namespace Rio.API.Controllers
             foreach (var mailMessage in mailMessages)
             {
                 SitkaSmtpClientService.AddBccRecipientsToEmail(mailMessage, 
-                    EFModels.Entities.User.EmailAddressesForAdminsThatReceiveSupportEmails(_dbContext));
+                    EFModels.Entities.User.GetEmailAddressesForAdminsThatReceiveSupportEmails(_dbContext));
                 SendEmailMessage(smtpClient, mailMessage);
             }
 

--- a/Source/Rio.API/Controllers/WaterTransferController.cs
+++ b/Source/Rio.API/Controllers/WaterTransferController.cs
@@ -175,7 +175,7 @@ namespace Rio.API.Controllers
             mailMessage.IsBodyHtml = true;
             mailMessage.From = SitkaSmtpClientService.GetDefaultEmailFrom();
             SitkaSmtpClientService.AddReplyToEmail(mailMessage);
-            SitkaSmtpClientService.AddAdminsAsBccRecipientsToEmail(mailMessage, EFModels.Entities.User.ListByRole(_dbContext, RoleEnum.Admin));
+            SitkaSmtpClientService.AddBccRecipientsToEmail(mailMessage, EFModels.Entities.User.EmailAddressesForAdminsThatReceiveSupportEmails(_dbContext));
             smtpClient.Send(mailMessage);
         }
 

--- a/Source/Rio.API/Controllers/WaterTransferController.cs
+++ b/Source/Rio.API/Controllers/WaterTransferController.cs
@@ -175,7 +175,7 @@ namespace Rio.API.Controllers
             mailMessage.IsBodyHtml = true;
             mailMessage.From = SitkaSmtpClientService.GetDefaultEmailFrom();
             SitkaSmtpClientService.AddReplyToEmail(mailMessage);
-            SitkaSmtpClientService.AddBccRecipientsToEmail(mailMessage, EFModels.Entities.User.EmailAddressesForAdminsThatReceiveSupportEmails(_dbContext));
+            SitkaSmtpClientService.AddBccRecipientsToEmail(mailMessage, EFModels.Entities.User.GetEmailAddressesForAdminsThatReceiveSupportEmails(_dbContext));
             smtpClient.Send(mailMessage);
         }
 

--- a/Source/Rio.API/Services/SitkaSmtpClientService.cs
+++ b/Source/Rio.API/Services/SitkaSmtpClientService.cs
@@ -178,9 +178,25 @@ Phone: (661) 589-6045<br />
             return defaultEmailSignature;
         }
 
+        public static string GetSupportNotificationEmailSignature()
+        {
+            const string supportNotificationEmailSignature = @"<br /><br />
+Respectfully, the RRB WSD Water Accounting Platform team
+<br /><br />
+***
+<br /><br />
+You have received this email because you are assigned to receive support notifications within the Rosedale-Rio Bravo WSD Water Accounting Platform. 
+<br /><br />
+P.O. Box 20820<br />
+Bakersfield, CA 93390-0820<br />
+Phone: (661) 589-6045<br />
+<a href=""mailto:admin@rrbwsd.com"">admin@rrbwsd.com</a>";
+            return supportNotificationEmailSignature;
+        }
+
         public static MailAddress GetDefaultEmailFrom()
         {
-            return new MailAddress("donotreply@sitkatech.com", "RRB Water Accounting Platform");
+            return new MailAddress("donotreply @sitkatech.com", "RRB Water Accounting Platform");
         }
 
         public static void AddAdminsAsBccRecipientsToEmail(MailMessage mailMessage, IEnumerable<UserDto> admins)
@@ -188,6 +204,14 @@ Phone: (661) 589-6045<br />
             foreach (var admin in admins)
             {
                 mailMessage.Bcc.Add(admin.Email);
+            }
+        }
+
+        public static void AddAdminsAsCCRecipientsToEmail(MailMessage mailMessage, IEnumerable<UserDto> admins)
+        {
+            foreach (var admin in admins)
+            {
+                mailMessage.CC.Add(admin.Email);
             }
         }
     }

--- a/Source/Rio.API/Services/SitkaSmtpClientService.cs
+++ b/Source/Rio.API/Services/SitkaSmtpClientService.cs
@@ -199,19 +199,19 @@ Phone: (661) 589-6045<br />
             return new MailAddress("donotreply @sitkatech.com", "RRB Water Accounting Platform");
         }
 
-        public static void AddAdminsAsBccRecipientsToEmail(MailMessage mailMessage, IEnumerable<UserDto> admins)
+        public static void AddBccRecipientsToEmail(MailMessage mailMessage, IEnumerable<string> recipients)
         {
-            foreach (var admin in admins)
+            foreach (var recipient in recipients)
             {
-                mailMessage.Bcc.Add(admin.Email);
+                mailMessage.Bcc.Add(recipient);
             }
         }
 
-        public static void AddAdminsAsCCRecipientsToEmail(MailMessage mailMessage, IEnumerable<UserDto> admins)
+        public static void AddCcRecipientsToEmail(MailMessage mailMessage, IEnumerable<string> recipients)
         {
-            foreach (var admin in admins)
+            foreach (var recipient in recipients)
             {
-                mailMessage.CC.Add(admin.Email);
+                mailMessage.CC.Add(recipient);
             }
         }
     }

--- a/Source/Rio.Database/Scripts/Views/dbo.vUserDetailed.sql
+++ b/Source/Rio.Database/Scripts/Views/dbo.vUserDetailed.sql
@@ -5,7 +5,7 @@ go
 create view dbo.vUserDetailed
 as
 
-select u.UserID, u.UserGuid, u.FirstName, u.LastName, u.Email, u.LoginName, u.Phone, u.Company, r.RoleID, r.RoleDisplayName,
+select u.UserID, u.UserGuid, u.FirstName, u.LastName, u.Email, u.LoginName, u.Phone, u.Company, u.ReceiveSupportEmails, r.RoleID, r.RoleDisplayName,
 		cast(sign(isnull(zz.AccountID, 0)) as bit) as HasActiveTrades, 
 		sum(case when wtr.WaterTransferTypeID = 1 then wt.AcreFeetTransferred else 0 end) as AcreFeetOfWaterPurchased,
 		sum(case when wtr.WaterTransferTypeID = 2 then wt.AcreFeetTransferred else 0 end) as AcreFeetOfWaterSold
@@ -28,7 +28,7 @@ left join (
 ) zz on au.AccountID = zz.AccountID
 left join dbo.WaterTransferRegistration wtr on au.AccountID = wtr.AccountID
 left join dbo.WaterTransfer wt on wtr.WaterTransferID = wt.WaterTransferID
-group by u.UserID, u.UserGuid, u.FirstName, u.LastName, u.Email, u.LoginName, u.Phone, u.Company, r.RoleID, r.RoleDisplayName, zz.AccountID
+group by u.UserID, u.UserGuid, u.FirstName, u.LastName, u.Email, u.LoginName, u.Phone, u.Company, u.ReceiveSupportEmails, r.RoleID, r.RoleDisplayName, zz.AccountID
 
 GO
 /*

--- a/Source/Rio.EFModels/Entities/Generated/RioDbContext.cs
+++ b/Source/Rio.EFModels/Entities/Generated/RioDbContext.cs
@@ -53,7 +53,6 @@ namespace Rio.EFModels.Entities
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/Source/Rio.EFModels/Entities/Generated/vUserDetailed.cs
+++ b/Source/Rio.EFModels/Entities/Generated/vUserDetailed.cs
@@ -24,6 +24,7 @@ namespace Rio.EFModels.Entities
         public string Phone { get; set; }
         [StringLength(100)]
         public string Company { get; set; }
+        public bool ReceiveSupportEmails { get; set; }
         public int RoleID { get; set; }
         [Required]
         [StringLength(100)]

--- a/Source/Rio.EFModels/Entities/User.cs
+++ b/Source/Rio.EFModels/Entities/User.cs
@@ -74,7 +74,7 @@ namespace Rio.EFModels.Entities
             return users;
         }
 
-        public static IEnumerable<string> EmailAddressesForAdminsThatReceiveSupportEmails(RioDbContext dbContext)
+        public static IEnumerable<string> GetEmailAddressesForAdminsThatReceiveSupportEmails(RioDbContext dbContext)
         {
             var users = GetUserImpl(dbContext)
                 .Where(x => x.IsActive && x.RoleID == (int) RoleEnum.Admin && x.ReceiveSupportEmails)

--- a/Source/Rio.EFModels/Entities/User.cs
+++ b/Source/Rio.EFModels/Entities/User.cs
@@ -56,6 +56,7 @@ namespace Rio.EFModels.Entities
                         HasActiveTrades = user.HasActiveTrades,
                         AcreFeetOfWaterPurchased = user.AcreFeetOfWaterPurchased,
                         AcreFeetOfWaterSold = user.AcreFeetOfWaterSold,
+                        ReceiveSupportEmails = user.ReceiveSupportEmails
                     };
                     return userDetailedDto;
                 }).ToList();

--- a/Source/Rio.EFModels/Entities/User.cs
+++ b/Source/Rio.EFModels/Entities/User.cs
@@ -74,11 +74,11 @@ namespace Rio.EFModels.Entities
             return users;
         }
 
-        public static IEnumerable<UserDto> AdminsThatReceiveSupportEmails(RioDbContext dbContext)
+        public static IEnumerable<string> EmailAddressesForAdminsThatReceiveSupportEmails(RioDbContext dbContext)
         {
             var users = GetUserImpl(dbContext)
                 .Where(x => x.IsActive && x.RoleID == (int) RoleEnum.Admin && x.ReceiveSupportEmails)
-                .Select(x => x.AsDto())
+                .Select(x => x.Email)
                 .AsEnumerable();
 
             return users;

--- a/Source/Rio.Web/src/app/pages/user-list/user-list.component.ts
+++ b/Source/Rio.Web/src/app/pages/user-list/user-list.component.ts
@@ -70,6 +70,7 @@ export class UserListComponent implements OnInit, OnDestroy {
           { headerName: 'Has Active Trades?', valueGetter: function (params) { return params.data.HasActiveTrades ? "Yes" : "No"; }, sortable: true, filter: true, width: 160 },
           { headerName: 'Water Purchased (ac-ft)', field: 'AcreFeetOfWaterPurchased', valueFormatter: function (params) { return _decimalPipe.transform(params.value, '1.0'); }, sortable: true, filter: true, width: 200 },
           { headerName: 'Water Sold (ac-ft)', field: 'AcreFeetOfWaterSold', valueFormatter: function (params) { return _decimalPipe.transform(params.value, '1.0'); }, sortable: true, filter: true, width: 160 },
+          { headerName: 'Receives System Communications?', field: 'ReceiveSupportEmails', valueGetter: function (params) { return params.data.ReceiveSupportEmails ? "Yes" : "No";}, sortable: true, filter: true },
         ];
         
         this.columnDefs.forEach(x => {

--- a/Source/Rio.Web/src/app/shared/models/user/user-detailed-dto.ts
+++ b/Source/Rio.Web/src/app/shared/models/user/user-detailed-dto.ts
@@ -16,6 +16,7 @@ export class UserDetailedDto {
     HasActiveTrades: boolean;
     AcreFeetOfWaterPurchased: number;
     AcreFeetOfWaterSold: number;
+    ReceiveSupportEmails: boolean;
 
     constructor(obj?: any) {
         Object.assign(this, obj);


### PR DESCRIPTION
On user creation each admin should no longer receive their own email but should all be cc'd on a single email that sends to donotreply@sitkatech.com. On account updates for a user each admin should remain bcc'd on the update email. Also added a column in the userlist table to reflect whether or not a user receives system communications. 