### PR TITLE
Bug/281

### DIFF
--- a/Source/Rio.API/Controllers/OfferController.cs
+++ b/Source/Rio.API/Controllers/OfferController.cs
@@ -55,7 +55,7 @@ namespace Rio.API.Controllers
 
             if (offerUpsertDto.OfferStatusID != (int) OfferStatusEnum.Rescinded && Posting.HasOpenOfferByMe(_dbContext, posting, offerUpsertDto.CreateAccountID))
             {
-                ModelState.AddModelError("Posting", "Posting already has an open offer");
+                ModelState.AddModelError("Posting", "You currently have an open offer on this posting. Please wait until the other party responds to the current offer.");
                 return BadRequest(ModelState);
             }
 
@@ -316,6 +316,14 @@ An offer to {offerAction} water {properPreposition} Account #{fromAccount.Accoun
         {
             var userDto = GetCurrentUser();
             var offerDtos = Offer.GetActiveOffersFromPostingIDAndUserID(_dbContext, postingID, userDto.UserID);
+            return Ok(offerDtos);
+        }
+
+        [HttpGet("current-account-active-offers/{accountID}/{postingID}")]
+        [OfferManageFeature]
+        public ActionResult<IEnumerable<OfferDto>> GetActiveOffersForCurrentAccountByPosting([FromRoute] int accountID, [FromRoute] int postingID)
+        {
+            var offerDtos = Offer.GetActiveOffersFromPostingIDAndCreateAccountID(_dbContext, postingID, accountID);
             return Ok(offerDtos);
         }
 

--- a/Source/Rio.API/Controllers/OfferController.cs
+++ b/Source/Rio.API/Controllers/OfferController.cs
@@ -53,7 +53,7 @@ namespace Rio.API.Controllers
                 return BadRequest(ModelState);
             }
 
-            if (Posting.HasOpenOffer(_dbContext, posting))
+            if (offerUpsertDto.OfferStatusID != (int) OfferStatusEnum.Rescinded && Posting.HasOpenOfferByMe(_dbContext, posting, offerUpsertDto.CreateAccountID))
             {
                 ModelState.AddModelError("Posting", "Posting already has an open offer");
                 return BadRequest(ModelState);
@@ -66,33 +66,27 @@ namespace Rio.API.Controllers
             var rioUrl = _rioConfiguration.WEB_URL;
 
             // update trades status if needed
-            if (offerUpsertDto.OfferStatusID == (int)OfferStatusEnum.Accepted)
+            switch (offerUpsertDto.OfferStatusID)
             {
-                var tradeDto = Trade.Update(_dbContext, offer.TradeID, TradeStatusEnum.Accepted);
-                // write a water transfer record
-                var waterTransfer = WaterTransfer.CreateNew(_dbContext, offer, tradeDto, posting);
-                var mailMessages = GenerateAcceptedOfferEmail(rioUrl, offer, currentTrade, posting, waterTransfer, smtpClient);
-                foreach (var mailMessage in mailMessages)
-                {
-                    SendEmailMessage(smtpClient, mailMessage);
-                }
-            }
-            else if (offerUpsertDto.OfferStatusID == (int)OfferStatusEnum.Rejected)
-            {
-                Trade.Update(_dbContext, offer.TradeID, TradeStatusEnum.Rejected);
-                var mailMessage = GenerateRejectedOfferEmail(rioUrl, offer, currentTrade, posting, smtpClient);
-                SendEmailMessage(smtpClient, mailMessage);
-            }
-            else if (offerUpsertDto.OfferStatusID == (int)OfferStatusEnum.Rescinded)
-            {
-                Trade.Update(_dbContext, offer.TradeID, TradeStatusEnum.Rescinded);
-                var mailMessage = GenerateRescindedOfferEmail(rioUrl, offer, currentTrade, posting, smtpClient);
-                SendEmailMessage(smtpClient, mailMessage);
-            }
-            else
-            {
-                var mailMessage = GeneratePendingOfferEmail(rioUrl, currentTrade, offer, posting, smtpClient);
-                SendEmailMessage(smtpClient, mailMessage);
+                case (int)OfferStatusEnum.Accepted:
+                    var tradeDto = Trade.Update(_dbContext, offer.TradeID, TradeStatusEnum.Accepted);
+                    // write a water transfer record
+                    var waterTransfer = WaterTransfer.CreateNew(_dbContext, offer, tradeDto, posting);
+                    var mailMessages = GenerateAcceptedOfferEmail(rioUrl, offer, currentTrade, posting, waterTransfer, smtpClient);
+                    foreach (var mailMessage in mailMessages)
+                    {
+                        SendEmailMessage(smtpClient, mailMessage);
+                    }
+                    break;
+                case (int)OfferStatusEnum.Rejected:
+                    UpdateTradeStatusSendEmail(offer, smtpClient, GenerateRejectedOfferEmail(rioUrl, offer, currentTrade, posting, smtpClient), TradeStatusEnum.Rejected);
+                    break;
+                case (int)OfferStatusEnum.Rescinded:
+                    UpdateTradeStatusSendEmail(offer, smtpClient, GenerateRescindedOfferEmail(rioUrl, offer, currentTrade, posting, smtpClient), TradeStatusEnum.Rescinded);
+                    break;
+                default:
+                    SendEmailMessage(smtpClient, GeneratePendingOfferEmail(rioUrl, currentTrade, offer, posting, smtpClient));
+                    break;
             }
 
             // get current balance of posting
@@ -103,7 +97,7 @@ namespace Rio.API.Controllers
                 postingStatusToUpdateTo = (int)PostingStatusEnum.Closed;
                 // expire all other outstanding offers
                 var postingCreateAccountID = posting.CreateAccount.AccountID;
-                var activeTradesForPosting = Trade.GetPendingTradesForPostingID(_dbContext, postingID);
+                var activeTradesForPosting = Trade.GetPendingTradesForPostingID(_dbContext, postingID).ToList();
                 foreach (var activeTrade in activeTradesForPosting)
                 {
                     var offerStatus = activeTrade.OfferCreateAccount.AccountID == postingCreateAccountID
@@ -113,17 +107,35 @@ namespace Rio.API.Controllers
                     {
                         TradeID = activeTrade.TradeID,
                         Price = activeTrade.Price,
+                        CreateAccountID = postingCreateAccountID,
                         Quantity = activeTrade.Quantity,
                         OfferStatusID = (int) offerStatus,
                         OfferNotes = $"Offer {offerStatus} because original posting is now closed"
                     };
-                    Offer.CreateNew(_dbContext, postingID, offerUpsertDtoForRescindReject);
+                    var resultingOffer = Offer.CreateNew(_dbContext, postingID, offerUpsertDtoForRescindReject);
+                    switch (offerStatus)
+                    {
+                        case OfferStatusEnum.Rejected:
+                            UpdateTradeStatusSendEmail(resultingOffer, smtpClient, GenerateRejectedOfferEmail(rioUrl, resultingOffer, Trade.GetByTradeID(_dbContext, activeTrade.TradeID), posting, smtpClient), TradeStatusEnum.Rejected);
+                            break;
+                        case OfferStatusEnum.Rescinded:
+                            UpdateTradeStatusSendEmail(resultingOffer, smtpClient, GenerateRescindedOfferEmail(rioUrl, resultingOffer, Trade.GetByTradeID(_dbContext, activeTrade.TradeID), posting, smtpClient), TradeStatusEnum.Rescinded);
+                            break;
+                    }
+
                 }
             }
             Posting.UpdateStatus(_dbContext, postingID,
                 new PostingUpdateStatusDto { PostingStatusID = postingStatusToUpdateTo }, posting.Quantity - acreFeetOfAcceptedTrades);
 
             return Ok(offer);
+        }
+
+        private void UpdateTradeStatusSendEmail(OfferDto offer, SitkaSmtpClientService smtpClient, MailMessage mailMessage,
+            TradeStatusEnum updatedStatus)
+        {
+            Trade.Update(_dbContext, offer.TradeID, updatedStatus);
+            SendEmailMessage(smtpClient, mailMessage);
         }
 
         private void SendEmailMessage(SitkaSmtpClientService smtpClient, MailMessage mailMessage)

--- a/Source/Rio.API/Controllers/OfferController.cs
+++ b/Source/Rio.API/Controllers/OfferController.cs
@@ -53,7 +53,7 @@ namespace Rio.API.Controllers
                 return BadRequest(ModelState);
             }
 
-            if (offerUpsertDto.OfferStatusID != (int) OfferStatusEnum.Rescinded && Posting.HasOpenOfferByMe(_dbContext, posting, offerUpsertDto.CreateAccountID))
+            if (offerUpsertDto.OfferStatusID != (int) OfferStatusEnum.Rescinded && Posting.HasOpenOfferByAccountID(_dbContext, posting, offerUpsertDto.CreateAccountID))
             {
                 ModelState.AddModelError("Posting", "You currently have an open offer on this posting. Please wait until the other party responds to the current offer.");
                 return BadRequest(ModelState);

--- a/Source/Rio.EFModels/Entities/Offer.cs
+++ b/Source/Rio.EFModels/Entities/Offer.cs
@@ -91,5 +91,16 @@ namespace Rio.EFModels.Entities
                                 x.Trade.Posting.CreateAccountID != x.CreateAccountID)).OrderByDescending(x => x.OfferDate).FirstOrDefault();
             return offer?.AsDto();
         }
+
+        public static object GetActiveOffersFromPostingIDAndCreateAccountID(RioDbContext dbContext, int postingID, int accountID)
+        {
+            var offers = GetOffersImpl(dbContext)
+                .Where(x => x.Trade.PostingID == postingID && x.CreateAccountID == accountID && x.Trade.TradeStatusID == (int)TradeStatusEnum.Countered)
+                .OrderByDescending(x => x.OfferDate)
+                .Select(x => x.AsDto())
+                .AsEnumerable();
+
+            return offers;
+        }
     }
 }

--- a/Source/Rio.EFModels/Entities/Posting.cs
+++ b/Source/Rio.EFModels/Entities/Posting.cs
@@ -3,6 +3,7 @@ using Rio.Models.DataTransferObjects.Posting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Rio.Models.DataTransferObjects.Offer;
 
 namespace Rio.EFModels.Entities
 {
@@ -143,10 +144,12 @@ namespace Rio.EFModels.Entities
             return offer?.AsDto();
         }
 
-        public static bool HasOpenOffer(RioDbContext dbContext, PostingDto posting)
+        public static bool HasOpenOfferByMe(RioDbContext dbContext, PostingDto posting, int createAccountID)
         {
             return dbContext.Trade.Any(x =>
-                x.PostingID == posting.PostingID && (x.TradeStatusID == (int) TradeStatusEnum.Accepted ||
+                x.PostingID == posting.PostingID && 
+                x.CreateAccountID == createAccountID &&
+                (x.TradeStatusID == (int) TradeStatusEnum.Accepted ||
                 x.TradeStatusID == (int) TradeStatusEnum.Countered));
         }
     }

--- a/Source/Rio.EFModels/Entities/Posting.cs
+++ b/Source/Rio.EFModels/Entities/Posting.cs
@@ -144,7 +144,7 @@ namespace Rio.EFModels.Entities
             return offer?.AsDto();
         }
 
-        public static bool HasOpenOfferByMe(RioDbContext dbContext, PostingDto posting, int createAccountID)
+        public static bool HasOpenOfferByAccountID(RioDbContext dbContext, PostingDto posting, int createAccountID)
         {
             return dbContext.Trade.Any(x =>
                 x.PostingID == posting.PostingID && 

--- a/Source/Rio.Web/src/app/pages/posting-detail/posting-detail.component.html
+++ b/Source/Rio.Web/src/app/pages/posting-detail/posting-detail.component.html
@@ -108,7 +108,7 @@
       </div>
 
       <div class="card"
-        *ngIf="currentAccountSet() && isPostingOpen() && !isPostingOwner() && !isConfirmingTrade && !isCounterOffering && !offerSubmittedSuccessfully">
+        *ngIf="currentAccountSet() && offersSet() && isPostingOpen() && !isPostingOwner() && !isConfirmingTrade && !isCounterOffering && !offerSubmittedSuccessfully">
         <div class="card-header">
           Your Offer
         </div>

--- a/Source/Rio.Web/src/app/pages/posting-detail/posting-detail.component.html
+++ b/Source/Rio.Web/src/app/pages/posting-detail/posting-detail.component.html
@@ -7,7 +7,7 @@
         </li>
         <li class="breadcrumb-item active" aria-current="page">
           Posting: <span *ngIf="posting">{{posting.PostingType.PostingTypeDisplayName}}
-          {{posting.Quantity | number: "1.0"}} ac-ft </span>
+            {{posting.Quantity | number: "1.0"}} ac-ft </span>
           <span *ngIf="!posting">Loading...</span>
         </li>
       </ol>
@@ -17,7 +17,7 @@
 <div class="container mt-sm-4">
   <h2 style="display: inline-block">
     Posting: <span *ngIf="posting">{{posting.PostingType.PostingTypeDisplayName}}
-    {{posting.Quantity | number: "1.0"}} ac-ft </span>
+      {{posting.Quantity | number: "1.0"}} ac-ft </span>
     <span *ngIf="!posting">Loading...</span>
   </h2>
   <app-alert-display></app-alert-display>
@@ -78,18 +78,37 @@
           Your Actions
         </div>
         <div class="card-body" *ngIf="isPostingOpen()">
-          <p>This is your posting.  View any offers on your dashboard.</p>
+          <p>This is your posting. View any offers on your dashboard.</p>
           <div class="text-center">
             <a class="btn btn-rio btn-sm mr-1" routerLink="/landowner-dashboard">View Dashboard</a>
             <button class="btn btn-rio btn-sm" (click)="closePosting()">Close Posting</button>
           </div>
         </div>
         <div class="card-body" *ngIf="!isPostingOpen()">
-          <p>Your posting is closed.  No further actions are allowed.</p>
+          <p>Your posting is closed. No further actions are allowed.</p>
         </div>
       </div>
 
-      <div class="card" *ngIf="isPostingOpen() && !isPostingOwner() && !isConfirmingTrade && !isCounterOffering && !offerSubmittedSuccessfully">
+      <div class="card" *ngIf="!currentAccountSet()">
+        <div class="card-header">
+          Your Offer
+        </div>
+        <div class="card-body">
+          <div class="row">
+            <div class="col-12">
+              <div class="alert alert-primary text-left" *ngIf="landownerHasAnyAccounts()">
+                No account is selected. Use the dropdown in the top right to select an account to make or view offers on this posting.
+              </div>
+              <div class="alert alert-primary text-left" *ngIf="!landownerHasAnyAccounts()">
+                You do not have any assigned accounts and cannot make any offers on this post.
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card"
+        *ngIf="currentAccountSet() && isPostingOpen() && !isPostingOwner() && !isConfirmingTrade && !isCounterOffering && !offerSubmittedSuccessfully">
         <div class="card-header">
           Your Offer
         </div>
@@ -114,12 +133,13 @@
             <div class="alert alert-primary text-left" *ngIf="!currentAccountSet()">
               No account is selected; please select an account before choosing an offer action.
             </div>
-            <button class="btn btn-rio btn-sm mr-1" *ngIf="offers.length == 0"
-              (click)="acceptCurrentOffer()" [disabled]="!currentAccountSet()">Accept Offer</button>
-            <button class="btn btn-rio btn-sm mr-1" (click)="isCounterOffering = true"
-              *ngIf="!isPendingOffer()" [disabled]="!currentAccountSet()">Make Counter
+            <button class="btn btn-rio btn-sm mr-1" *ngIf="offers.length == 0" (click)="acceptCurrentOffer()"
+              [disabled]="!currentAccountSet()">Accept Offer</button>
+            <button class="btn btn-rio btn-sm mr-1" (click)="isCounterOffering = true" *ngIf="!isPendingOffer()"
+              [disabled]="!currentAccountSet()">Make Counter
               Offer</button>
-            <button class="btn btn-rio btn-sm" (click)="rescindOffer()" *ngIf="isPendingOffer()" [disabled]="!currentAccountSet()">Rescind Offer</button>
+            <button class="btn btn-rio btn-sm" (click)="rescindOffer()" *ngIf="isPendingOffer()"
+              [disabled]="!currentAccountSet()">Rescind Offer</button>
           </div>
         </div>
       </div>
@@ -131,9 +151,9 @@
         <div class="card-body">
           <p>Offer successfully submitted, no further actions needed.</p>
           <div class="text-center">
-          <a class="btn btn-rio btn-sm mr-1" routerLink="/landowner-dashboard">View Dashboard</a>
-          <a class="btn btn-rio btn-sm mr-1" routerLink="/trades">View Postings List</a>
-        </div>
+            <a class="btn btn-rio btn-sm mr-1" routerLink="/landowner-dashboard">View Dashboard</a>
+            <a class="btn btn-rio btn-sm mr-1" routerLink="/trades">View Postings List</a>
+          </div>
         </div>
       </div>
 
@@ -146,7 +166,8 @@
             <dt class="text-sm-right col-sm-5 col-xs-12">{{offerType}} Quantity</dt>
             <dd class="col-sm-7 col-xs-12">
               <div class="input-group">
-                <input type="number" class="form-control" name="Quantity" required [(ngModel)]="model.Quantity" min="1" step="1" />
+                <input type="number" class="form-control" name="Quantity" required [(ngModel)]="model.Quantity" min="1"
+                  step="1" />
                 <div class="input-group-append">
                   <span class="input-group-text"> ac-ft</span>
                 </div>
@@ -159,7 +180,8 @@
                 <div class="input-group-prepend">
                   <span class="input-group-text">$</span>
                 </div>
-                <input type="number" class="form-control" name="Price" required [(ngModel)]="model.Price" min="1" step=".01" />
+                <input type="number" class="form-control" name="Price" required [(ngModel)]="model.Price" min="1"
+                  step=".01" />
                 <div class="input-group-append">
                   <span class="input-group-text"> per ac-ft</span>
                 </div>
@@ -174,11 +196,12 @@
             <dt class="text-sm-right col-sm-5 col-xs-12">Notes</dt>
             <dd class="col-sm-7 col-xs-12">
               <textarea class="form-control" name="OfferNotes" style="height: 200px"
-              [(ngModel)]="model.OfferNotes"></textarea>
+                [(ngModel)]="model.OfferNotes"></textarea>
             </dd>
           </dl>
           <div class="text-center">
-            <button class="btn btn-rio btn-sm mr-1" (click)="isConfirmingTrade = true" [disabled]="!isOfferFormValid()">Present Counter
+            <button class="btn btn-rio btn-sm mr-1" (click)="isConfirmingTrade = true"
+              [disabled]="!isOfferFormValid()">Present Counter
               Offer</button>
             <button class="btn btn-rio btn-sm" (click)="cancelCounterOffer()">Cancel</button>
           </div>
@@ -191,9 +214,10 @@
         <div class="card-body">
           <p *ngIf="!isRescindingTrade && !isRejectingTrade && !isCounterOffering">Please confirm your intent to execute
             this trade agreement.<br />
-            <strong>This action is final</strong> and obligates you to complete the financial 
-            transaction according to the quantity and price specified here. You will receive email confirmation of the 
-            pending trade, including the contact information of the other party. After the financial transaction is complete 
+            <strong>This action is final</strong> and obligates you to complete the financial
+            transaction according to the quantity and price specified here. You will receive email confirmation of the
+            pending trade, including the contact information of the other party. After the financial transaction is
+            complete
             and acknowledged by both parties your annual water allocation will be adjusted accordingly.</p>
           <p *ngIf="isRescindingTrade">Please confirm you wish to rescind your current offer.</p>
           <p *ngIf="isRejectingTrade">Please confirm you wish to reject further negotiations. You will no longer be able

--- a/Source/Rio.Web/src/app/pages/posting-detail/posting-detail.component.ts
+++ b/Source/Rio.Web/src/app/pages/posting-detail/posting-detail.component.ts
@@ -72,6 +72,7 @@ export class PostingDetailComponent implements OnInit, OnDestroy {
                         this.cdr.detectChanges();
                     });
                 }
+                this.cdr.detectChanges();
             });
             const postingID = parseInt(this.route.snapshot.paramMap.get("postingID"));
             if (postingID) {
@@ -206,6 +207,10 @@ export class PostingDetailComponent implements OnInit, OnDestroy {
 
     public currentAccountSet(): boolean {
         return this.currentAccount !== null && this.currentAccount !== undefined;
+    }
+
+    public offersSet(): boolean {
+        return  this.offers !== null &&  this.offers !== undefined;
     }
 
     public landownerHasAnyAccounts(){

--- a/Source/Rio.Web/src/app/pages/posting-detail/posting-detail.component.ts
+++ b/Source/Rio.Web/src/app/pages/posting-detail/posting-detail.component.ts
@@ -58,9 +58,21 @@ export class PostingDetailComponent implements OnInit, OnDestroy {
     ngOnInit() {
         this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
             this.currentUser = currentUser;
-            this.authenticationService.getActiveAccount().subscribe(account=>{
-                this.currentAccount = account;
-            })
+            this.authenticationService.getActiveAccount().subscribe(account => {
+                if (account) {
+                    this.currentAccount = account;
+                    this.offerService.getActiveOffersFromPostingIDForCurrentAccount(postingID, account.AccountID).subscribe(offers => {
+                        this.offers = offers.sort((a, b) => a.OfferDate > b.OfferDate ? -1 : a.OfferDate < b.OfferDate ? 1 : 0);
+                        this.resetModelToPosting();
+                        this.originalPostingType = this.posting.PostingType;
+                        this.offerType = this.isPostingOwner ?
+                            (this.originalPostingType.PostingTypeID === PostingTypeEnum.OfferToBuy ? "Purchasing" : "Selling")
+                            : (this.originalPostingType.PostingTypeID === PostingTypeEnum.OfferToBuy ? "Selling" : "Purchasing");
+                        this.counterOfferRecipientType = this.offerType === "Purchasing" ? "seller" : "buyer";
+                        this.cdr.detectChanges();
+                    });
+                }
+            });
             const postingID = parseInt(this.route.snapshot.paramMap.get("postingID"));
             if (postingID) {
                 forkJoin(
@@ -70,13 +82,6 @@ export class PostingDetailComponent implements OnInit, OnDestroy {
                     this.posting = posting instanceof Array
                         ? null
                         : posting as PostingDto;
-                    this.offers = offers.sort((a, b) => a.OfferDate > b.OfferDate ? -1 : a.OfferDate < b.OfferDate ? 1 : 0);
-                    this.resetModelToPosting();
-                    this.originalPostingType = this.posting.PostingType;
-                    this.offerType = this.isPostingOwner ?
-                        (this.originalPostingType.PostingTypeID === PostingTypeEnum.OfferToBuy ? "Purchasing" : "Selling")
-                        : (this.originalPostingType.PostingTypeID === PostingTypeEnum.OfferToBuy ? "Selling" : "Purchasing");
-                    this.counterOfferRecipientType = this.offerType === "Purchasing" ? "seller" : "buyer";
                     this.cdr.detectChanges();
                 });
             }
@@ -89,7 +94,7 @@ export class PostingDetailComponent implements OnInit, OnDestroy {
         this.cdr.detach();
     }
 
-    public isPostingOwner(): boolean{
+    public isPostingOwner(): boolean {
         return (this.currentAccount) && this.posting.CreateAccount.AccountID === this.currentAccount.AccountID;
     }
 
@@ -202,4 +207,9 @@ export class PostingDetailComponent implements OnInit, OnDestroy {
     public currentAccountSet(): boolean {
         return this.currentAccount !== null && this.currentAccount !== undefined;
     }
+
+    public landownerHasAnyAccounts(){
+        var result = this.authenticationService.getAvailableAccounts();
+        return result != null && result.length > 0;
+      }
 }

--- a/Source/Rio.Web/src/app/pages/register-transfer/register-transfer.component.html
+++ b/Source/Rio.Web/src/app/pages/register-transfer/register-transfer.component.html
@@ -59,7 +59,7 @@
             </div>
             <div class="mt-2" *ngIf="canCancelTrade()">
                 <small class="cancelTradeTitle">
-                    <a class="collapsed" data-toggle="collapse" href="#cancelTradePanel" role="button" aria-expanded="false"
+                    <a class="icon collapsed" data-toggle="collapse" href="#cancelTradePanel" role="button" aria-expanded="false"
                         aria-controls="cancelTradePanel" (click)="confirmedFullNameForCancelation = null">
                         What if I am unable to complete this transaction?
                     </a>

--- a/Source/Rio.Web/src/app/pages/register-transfer/register-transfer.component.scss
+++ b/Source/Rio.Web/src/app/pages/register-transfer/register-transfer.component.scss
@@ -1,10 +1,20 @@
 .cancelTradeTitle a:before {
-    font-family:Fontawesome;
-    content:'\f077';
-    font-size:10px;
-    font-weight:300;
+    font-family:"Font Awesome 5 Free";
+    content:'\f0d7';
+    font-size:15px;
+    font-weight:900;
 }
 .cancelTradeTitle a.collapsed:before {
-    font-family:Fontawesome;
-    content:'\f078';
+    font-family:"Font Awesome 5 Free";
+    font-weight:900;
+    font-size:15px;
+    content:'\f0da';
 }
+
+.icon::before {
+    display: inline-block;
+    font-style: normal;
+    font-variant: normal;
+    text-rendering: auto;
+    -webkit-font-smoothing: antialiased;
+  }

--- a/Source/Rio.Web/src/app/services/offer.service.ts
+++ b/Source/Rio.Web/src/app/services/offer.service.ts
@@ -16,6 +16,11 @@ export class OfferService {
         return this.apiService.getFromApi(route);
     }
 
+    getActiveOffersFromPostingIDForCurrentAccount(postingID: number, accountID: number): Observable<OfferDto[]> {
+        let route = `/current-account-active-offers/${accountID}/${postingID}`;
+        return this.apiService.getFromApi(route);
+    }
+
     getOfferFromOfferID(offerID: number): Observable<OfferDto> {
         let route = `/offers/${offerID}`;
         return this.apiService.getFromApi(route);


### PR DESCRIPTION
-Fixes trade logic that was barring any actions from being  taken beyond the first counter (if anyone countered)
-Cleans up some offer logic in the api (if/else to switch, repeated code in function)
-When expiring offers, the createAccountID is set correctly and the trade containing the expired  offer is  updated to reflect so  as to prevent users from being able to  continue making offers on a closed posting