### PR TITLE
Update CIMIS precip job based on feedback from the Support people to …

### DIFF
--- a/Source/Rio.API/CimisPrecipJob.cs
+++ b/Source/Rio.API/CimisPrecipJob.cs
@@ -48,7 +48,7 @@ namespace Rio.API
 
             var appKey = _rioConfiguration.CimisAppKey;
 
-            var cimisRequestUrl = CimisBaseUrl + $"&appKey={appKey}&startDate={startDateString}&endDate={endDateString}";
+            var cimisRequestUrl = CimisBaseUrl + $"&appKey={appKey}&startDate={startDateString}&endDate={endDateString}&unitsOfMeasure=E";
             
             var httpClient = new HttpClient();
 


### PR DESCRIPTION
…prevent the  job from failing. Evidently there was a parameter that should've been defaulting that wasn't, and adding the new queryParam did the trick