### PR TITLE
Bugs/rio 360

### DIFF
--- a/Source/Rio.Web/src/app/app.component.ts
+++ b/Source/Rio.Web/src/app/app.component.ts
@@ -1,9 +1,7 @@
 import { Component, Inject } from '@angular/core';
-import { OAuthService, OAuthSuccessEvent } from 'angular-oauth2-oidc';
+import { OAuthService } from 'angular-oauth2-oidc';
 import { JwksValidationHandler } from 'angular-oauth2-oidc-jwks';
-import { Subject, Observable } from 'rxjs';
 import { environment } from '../environments/environment';
-import { CookieStorageService } from './shared/services/cookies/cookie-storage.service';
 import { Router, RouteConfigLoadStart, RouteConfigLoadEnd, NavigationEnd } from '@angular/router';
 import { BusyService } from './shared/services';
 import { AuthenticationService } from './services/authentication.service';
@@ -20,14 +18,17 @@ declare var require: any
 export class AppComponent {
 
     userClaimsUpsertStarted = false;
-    ignoreSessionTerminated = false;
 
-    constructor(private router: Router, 
-        private oauthService: OAuthService, 
-        private busyService: BusyService, 
-        private authenticationService: AuthenticationService, 
-        private titleService: Title, 
-        @Inject(DOCUMENT) private _document: HTMLDocument) {
+    constructor(
+        private router: Router,
+        private oauthService: OAuthService,
+        private busyService: BusyService,
+        private authenticationService: AuthenticationService,
+        private titleService: Title,
+        @Inject(DOCUMENT) private _document: HTMLDocument
+    ) {
+        this.configureOAuthService();
+        this.authenticationService.initialLoginSequence();
     }
 
     ngOnInit() {
@@ -40,67 +41,14 @@ export class AppComponent {
                 window.scrollTo(0, 0);
             }
         });
-        
-        this.configureAuthService().subscribe(() => {
-            this.oauthService.tryLogin();
-        });
 
         this.titleService.setTitle(`${environment.leadOrganizationShortName} ${environment.platformShortName}`)
         this.setAppFavicon();
     }
 
-    private configureAuthService(): Observable<void> {
-        const subject = new Subject<void>();
+    private configureOAuthService() {
         this.oauthService.configure(environment.keystoneAuthConfiguration);
-        this.oauthService.setupAutomaticSilentRefresh();
         this.oauthService.tokenValidationHandler = new JwksValidationHandler();
-        this.oauthService.loadDiscoveryDocument();
-        this.oauthService.events
-            .subscribe((e) => {
-                console.log(e.type);
-                switch (e.type) {
-                    case 'discovery_document_loaded':
-                        console.log("discovery_document_loaded");
-                        if ((e as OAuthSuccessEvent).info) {
-                            subject.next();
-                            subject.complete();
-                        }
-                        break;
-                    case 'token_received':
-                        console.log("token_received");
-                        subject.next();
-                        subject.complete();
-                        break;
-                    case 'token_refreshed':
-                        subject.next();
-                        subject.complete();
-                        this.authenticationService.checkAuthentication();
-                        break;
-                    case 'token_refresh_error':
-                        console.log("token_refresh_error");
-                        this.authenticationService.forcedLogout();
-                        break;
-                    // case 'session_changed':
-                    //     console.log("session_changed");
-                    //     // when the user logins from no-tenant URL and then jumps to the tenant URL,
-                    //     // the oAuthService triggers a session-changed followed by a session_terminated...
-                    //     // however the token still works as expected.
-                    //     // ATTENTION: Need to verify that on session expiration (and hence session_terminated) this session_changed doesn't get called...
-                    //     this.ignoreSessionTerminated = true;
-                    //     break;
-                    // case 'session_terminated':
-                    //     if (!this.ignoreSessionTerminated) {
-                    //         console.warn('Your session has been terminated!');
-                    //         this.cookieStorageService.removeAll();
-                    //     }
-                    //     debugger;
-                    //     this.ignoreSessionTerminated = false;
-                    //     break;
-                }
-
-            });
-
-        return subject.asObservable();
     }
 
     setAppFavicon(){

--- a/Source/Rio.Web/src/app/pages/account-detail/account-detail.component.ts
+++ b/Source/Rio.Web/src/app/pages/account-detail/account-detail.component.ts
@@ -18,7 +18,7 @@ import { UserDto } from 'src/app/shared/generated/model/user-dto';
   styleUrls: ['./account-detail.component.scss']
 })
 export class AccountDetailComponent implements OnInit, OnDestroy {
-  private watchUserChangeSubscription: any;
+  
   private currentUser: UserDto;
 
   public account: AccountDto;
@@ -39,7 +39,7 @@ export class AccountDetailComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-      this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+      this.authenticationService.getCurrentUser().subscribe(currentUser => {
           this.currentUser = currentUser;
           const id = parseInt(this.route.snapshot.paramMap.get("id"));
           if (id) {
@@ -60,8 +60,8 @@ export class AccountDetailComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-      this.watchUserChangeSubscription.unsubscribe();
-      this.authenticationService.dispose();
+      
+      
       this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/account-edit-users/account-edit-users.component.ts
+++ b/Source/Rio.Web/src/app/pages/account-edit-users/account-edit-users.component.ts
@@ -18,7 +18,7 @@ import { UserSimpleDto } from 'src/app/shared/generated/model/user-simple-dto';
   styleUrls: ['./account-edit-users.component.scss']
 })
 export class AccountEditUsersComponent implements OnInit, OnDestroy {
-  public watchUserChangeSubscription: any;
+  
   public currentUser: UserDto;
   public accountID: number;
   public account: AccountDto;
@@ -50,7 +50,7 @@ export class AccountEditUsersComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.allUsers = new Array<UserDto>();
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       this.currentUser = currentUser;
       this.accountID = parseInt(this.route.snapshot.paramMap.get("id"));
 
@@ -68,8 +68,8 @@ export class AccountEditUsersComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.watchUserChangeSubscription.unsubscribe();
-    this.authenticationService.dispose();
+    
+    
     this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/account-edit/account-edit.component.ts
+++ b/Source/Rio.Web/src/app/pages/account-edit/account-edit.component.ts
@@ -18,7 +18,7 @@ import { UserDto } from 'src/app/shared/generated/model/user-dto';
   styleUrls: ['./account-edit.component.scss']
 })
 export class AccountEditComponent implements OnInit {
-  private watchUserChangeSubscription: any;
+  
   private currentUser: UserDto;
 
   public accountID: number;
@@ -41,7 +41,7 @@ export class AccountEditComponent implements OnInit {
   ngOnInit() {
     this.model = new AccountUpdateDto();
     
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       this.currentUser = currentUser;
 
       if (!this.authenticationService.isUserAnAdministrator(this.currentUser)) {
@@ -78,8 +78,8 @@ export class AccountEditComponent implements OnInit {
   }
 
   ngOnDestroy() {
-    this.watchUserChangeSubscription.unsubscribe();
-    this.authenticationService.dispose();
+    
+    
     this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/account-list/account-list.component.ts
+++ b/Source/Rio.Web/src/app/pages/account-list/account-list.component.ts
@@ -18,7 +18,7 @@ import { UserDto } from 'src/app/shared/generated/model/user-dto';
 })
 export class AccountListComponent implements OnInit, OnDestroy {
   @ViewChild("accountsGrid") accountsGrid: AgGridAngular;
-  private watchUserChangeSubscription: any;
+  
   private currentUser: UserDto;
 
   public accounts: Array<AccountDto>
@@ -35,9 +35,9 @@ export class AccountListComponent implements OnInit, OnDestroy {
     private utilityFunctionsService: UtilityFunctionsService) { }
 
   ngOnInit() {
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       this.currentUser = currentUser;
-      this.accountsGrid.api.showLoadingOverlay();
+      this.accountsGrid?.api.showLoadingOverlay();
       this.accountService.listAllAccounts().subscribe(accounts => {
         this.accounts = accounts;
         this.rowData = accounts.filter(x => x.AccountStatus.AccountStatusID === AccountStatusEnum.Active);
@@ -224,8 +224,8 @@ export class AccountListComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.watchUserChangeSubscription.unsubscribe();
-    this.authenticationService.dispose();
+    
+    
     this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/account-new/account-new.component.ts
+++ b/Source/Rio.Web/src/app/pages/account-new/account-new.component.ts
@@ -26,7 +26,7 @@ export class AccountNewComponent implements OnInit {
   constructor(private accountService: AccountService, private router: Router, private alertService: AlertService, private cdr: ChangeDetectorRef, private accountStatusService: AccountStatusService, private authenticationService: AuthenticationService) { }
 
   ngOnInit() {
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       this.currentUser = currentUser;
       this.model = new AccountUpdateDto();
       this.accountStatusService.getAccountStatuses().subscribe(accountStatuses => {

--- a/Source/Rio.Web/src/app/pages/account-reconciliation/account-reconciliation.component.ts
+++ b/Source/Rio.Web/src/app/pages/account-reconciliation/account-reconciliation.component.ts
@@ -20,7 +20,7 @@ export class AccountReconciliationComponent implements OnInit {
 
   public richTextTypeID: number = CustomRichTextType.AccountReconciliationReport;
 
-  private watchUserChangeSubscription: any;
+  
   private currentUser: UserDto;
   public gridOptions: GridOptions;
   public rowData = [];
@@ -51,7 +51,7 @@ export class AccountReconciliationComponent implements OnInit {
     private accountReconciliationService: AccountReconciliationService) { }
 
   ngOnInit() {
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
 
       this.columnDefs = [
         {
@@ -127,7 +127,7 @@ export class AccountReconciliationComponent implements OnInit {
 
       this.gridOptions = <GridOptions>{};
       this.currentUser = currentUser;
-      this.accountReconciliationGrid.api.showLoadingOverlay();
+      this.accountReconciliationGrid?.api.showLoadingOverlay();
 
       this.accountReconciliationService.getAccountsToBeReconciled().subscribe((parcels) => {
         this.rowData = parcels;
@@ -144,8 +144,8 @@ export class AccountReconciliationComponent implements OnInit {
   }
 
   ngOnDestroy() {
-    this.watchUserChangeSubscription.unsubscribe();
-    this.authenticationService.dispose();
+    
+    
     this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/create-user-profile/create-user-profile.component.ts
+++ b/Source/Rio.Web/src/app/pages/create-user-profile/create-user-profile.component.ts
@@ -10,7 +10,7 @@ import { CustomRichTextType } from 'src/app/shared/models/enums/custom-rich-text
 })
 export class CreateUserProfileComponent implements OnInit {
 
-  private watchUserChangeSubscription: any;
+  
   public currentUser: UserDto;
   
   public introRichText : number = CustomRichTextType.CreateUserProfile;

--- a/Source/Rio.Web/src/app/pages/create-water-transactions/create-water-transactions.component.ts
+++ b/Source/Rio.Web/src/app/pages/create-water-transactions/create-water-transactions.component.ts
@@ -9,7 +9,7 @@ import { UserDto } from 'src/app/shared/generated/model/user-dto';
   styleUrls: ['./create-water-transactions.component.scss']
 })
 export class CreateWaterTransactionsComponent implements OnInit, OnDestroy {
-  private watchUserChangeSubscription: any;
+  
   private currentUser: UserDto;
   public richTextTypeID: number = CustomRichTextType.CreateWaterTransactions;
 
@@ -18,14 +18,14 @@ export class CreateWaterTransactionsComponent implements OnInit, OnDestroy {
     private authenticationService: AuthenticationService) { }
 
   ngOnInit(): void {
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       this.currentUser = currentUser;
     });
   }
 
   ngOnDestroy() {
-    this.watchUserChangeSubscription.unsubscribe();
-    this.authenticationService.dispose();
+    
+    
     this.cdr.detach();
   }
 }

--- a/Source/Rio.Web/src/app/pages/disclaimer/disclaimer.component.ts
+++ b/Source/Rio.Web/src/app/pages/disclaimer/disclaimer.component.ts
@@ -27,7 +27,7 @@ export class DisclaimerComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       this.currentUser = currentUser;
     });
     this.route.queryParams.subscribe(params => {

--- a/Source/Rio.Web/src/app/pages/home/home-index/home-index.component.ts
+++ b/Source/Rio.Web/src/app/pages/home/home-index/home-index.component.ts
@@ -39,7 +39,7 @@ export class HomeIndexComponent implements OnInit, OnDestroy {
                 this.authenticationService.login();
             }
 
-            this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+            this.authenticationService.getCurrentUser().subscribe(currentUser => {
                 this.currentUser = currentUser;
                 if (currentUser && !this.userIsUnassigned() && !this.userRoleIsDisabled()) {
                     this.currentUserAccounts = this.authenticationService.getAvailableAccounts();

--- a/Source/Rio.Web/src/app/pages/landowner-dashboard/landowner-dashboard.component.ts
+++ b/Source/Rio.Web/src/app/pages/landowner-dashboard/landowner-dashboard.component.ts
@@ -48,7 +48,7 @@ export class LandownerDashboardComponent implements OnInit, OnDestroy {
   
   public waterYearToDisplay: WaterYearDto;
   public currentUser: UserDto;
-  private watchUserChangeSubscription: any;
+  
   private watchAccountChangeSubscription: any;
   public showAcresManagedDetails: boolean;
   public showSupplyDetails: boolean;
@@ -138,7 +138,7 @@ export class LandownerDashboardComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.loadingActiveAccount = true;
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       this.currentUser = currentUser;
       this.tradeStatusIDs = [TradeStatusEnum.Accepted, TradeStatusEnum.Countered, TradeStatusEnum.Rejected, TradeStatusEnum.Rescinded];
       this.postingStatusIDs = [PostingStatusEnum.Open, PostingStatusEnum.Closed];
@@ -252,9 +252,9 @@ export class LandownerDashboardComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.watchUserChangeSubscription.unsubscribe();
+    
     this.watchAccountChangeSubscription?.unsubscribe();
-    this.authenticationService.dispose();
+    
     this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/login-callback/login-callback.component.ts
+++ b/Source/Rio.Web/src/app/pages/login-callback/login-callback.component.ts
@@ -17,10 +17,11 @@ export class LoginCallbackComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
-        if (sessionStorage.getItem("authRedirectUrl")) {
-          this.router.navigateByUrl(sessionStorage.getItem("authRedirectUrl"))
+      let authRedirectUrl = this.authenticationService.getAuthRedirectUrl();  
+      if (authRedirectUrl && authRedirectUrl !== "/") {
+          this.router.navigateByUrl(authRedirectUrl)
               .then(() => {
-                  sessionStorage.removeItem("authRedirectUrl");
+                  this.authenticationService.clearAuthRedirectUrl();
               });
         } 
         else if (this.authenticationService.isUserAnAdministrator(currentUser)){

--- a/Source/Rio.Web/src/app/pages/login-callback/login-callback.component.ts
+++ b/Source/Rio.Web/src/app/pages/login-callback/login-callback.component.ts
@@ -9,14 +9,14 @@ import { UserService } from 'src/app/services/user/user.service';
   styleUrls: ['./login-callback.component.scss']
 })
 export class LoginCallbackComponent implements OnInit, OnDestroy {
-  private watchUserChangeSubscription: any;
+  
 
   constructor(private router: Router, 
     private authenticationService: AuthenticationService,
     private userService: UserService) { }
 
   ngOnInit() {
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       let authRedirectUrl = this.authenticationService.getAuthRedirectUrl();  
       if (authRedirectUrl && authRedirectUrl !== "/") {
           this.router.navigateByUrl(authRedirectUrl)
@@ -41,6 +41,6 @@ export class LoginCallbackComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.watchUserChangeSubscription.unsubscribe();
+    
   }
 }

--- a/Source/Rio.Web/src/app/pages/manager-dashboard/manager-dashboard.component.ts
+++ b/Source/Rio.Web/src/app/pages/manager-dashboard/manager-dashboard.component.ts
@@ -43,7 +43,7 @@ export class ManagerDashboardComponent implements OnInit, OnDestroy {
   public modalReference: NgbModalRef;
 
 
-  private watchUserChangeSubscription: any;
+  
   public currentUser: UserDto;
 
   public parcels: Array<ParcelDto>;
@@ -108,7 +108,7 @@ export class ManagerDashboardComponent implements OnInit, OnDestroy {
     ) { }
 
   ngOnInit() {
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       this.currentUser = currentUser;
       this.initializeTradeActivityGrid();
       this.initializePostingActivityGrid();
@@ -157,8 +157,8 @@ export class ManagerDashboardComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.watchUserChangeSubscription.unsubscribe();
-    this.authenticationService.dispose();
+    
+    
     this.cdr.detach();
   }
 
@@ -545,7 +545,7 @@ export class ManagerDashboardComponent implements OnInit, OnDestroy {
       this.parcels = parcels;
     })
     if (this.landOwnerUsageReportGrid) {
-      this.landOwnerUsageReportGrid.api.showLoadingOverlay();
+      this.landOwnerUsageReportGrid?.api.showLoadingOverlay();
     }
     this.userService.getLandownerUsageReportByYear(this.waterYearToDisplay.Year).subscribe(result => {
       if (!this.landOwnerUsageReportGrid) {

--- a/Source/Rio.Web/src/app/pages/market-metrics-home/market-metrics-home.component.ts
+++ b/Source/Rio.Web/src/app/pages/market-metrics-home/market-metrics-home.component.ts
@@ -14,7 +14,7 @@ import { UserDto } from 'src/app/shared/generated/model/user-dto';
   styleUrls: ['./market-metrics-home.component.scss']
 })
 export class MarketMetricsHomeComponent implements OnInit, OnDestroy {
-  private watchUserChangeSubscription: any;
+  
   private currentUser: UserDto;
   marketMetrics: MarketMetricsDto;
   tradeActivityByMonth: TradeActivityByMonthDto[];
@@ -35,7 +35,7 @@ export class MarketMetricsHomeComponent implements OnInit, OnDestroy {
 ) { }
 
   ngOnInit() {
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       this.currentUser = currentUser;
       forkJoin(this.marketMetricsService.getMarketMetrics(), this.marketMetricsService.getMonthlyTradeActivity()).subscribe(([marketMetrics, tradeActivityByMonth]) => {
         this.marketMetrics = marketMetrics;
@@ -60,8 +60,8 @@ export class MarketMetricsHomeComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.watchUserChangeSubscription.unsubscribe();
-    this.authenticationService.dispose();
+    
+    
     this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/openet-sync-water-year-month-status-list/openet-sync-water-year-month-status-list.component.ts
+++ b/Source/Rio.Web/src/app/pages/openet-sync-water-year-month-status-list/openet-sync-water-year-month-status-list.component.ts
@@ -22,7 +22,7 @@ import { WaterYearMonthDto } from 'src/app/shared/generated/model/water-year-mon
   styleUrls: ['./openet-sync-water-year-month-status-list.component.scss']
 })
 export class OpenetSyncWaterYearMonthStatusListComponent implements OnInit {
-  public watchUserChangeSubscription: any;
+  
   public currentUser: UserDto;
   public richTextTypeID: number = CustomRichTextType.OpenETIntegration;
   public modalReference: NgbModalRef;
@@ -50,7 +50,7 @@ export class OpenetSyncWaterYearMonthStatusListComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       this.loadingPage = true;
       this.currentUser = currentUser;
       this.openETService.isApiKeyValid().subscribe(isValid => {

--- a/Source/Rio.Web/src/app/pages/parcel-change-owner/parcel-change-owner.component.ts
+++ b/Source/Rio.Web/src/app/pages/parcel-change-owner/parcel-change-owner.component.ts
@@ -64,7 +64,7 @@ export class ParcelChangeOwnerComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.loadingFormData = true;
-    this.watchAccountChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.watchAccountChangeSubscription = this.authenticationService.getCurrentUser().subscribe(currentUser => {
       this.parcelID = parseInt(this.route.snapshot.paramMap.get("id"));
       this.parcelToBeInactivated = false;
       forkJoin(
@@ -84,7 +84,7 @@ export class ParcelChangeOwnerComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.watchAccountChangeSubscription.unsubscribe();
-    this.authenticationService.dispose();
+    
     this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/parcel-detail/parcel-detail.component.ts
+++ b/Source/Rio.Web/src/app/pages/parcel-detail/parcel-detail.component.ts
@@ -26,7 +26,7 @@ import { ParcelLedgerEntrySourceTypeEnum } from 'src/app/shared/models/enums/par
 })
 export class ParcelDetailComponent implements OnInit, OnDestroy {
   @ViewChild('parcelLedgerGrid') parcelLedgerGrid: AgGridAngular;
-  private watchUserChangeSubscription: any;
+  
   private currentUser: UserDto;
   private currentUserAccounts: AccountSimpleDto[];
 
@@ -62,7 +62,7 @@ export class ParcelDetailComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       this.currentUser = currentUser;
       this.currentUserAccounts = this.authenticationService.getAvailableAccounts();
       const id = parseInt(this.route.snapshot.paramMap.get("id"));
@@ -164,8 +164,8 @@ export class ParcelDetailComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.watchUserChangeSubscription.unsubscribe();
-    this.authenticationService.dispose();
+    
+    
     this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/parcel-ledger-bulk-create/parcel-ledger-bulk-create.component.ts
+++ b/Source/Rio.Web/src/app/pages/parcel-ledger-bulk-create/parcel-ledger-bulk-create.component.ts
@@ -29,7 +29,7 @@ import { ParcelAllocationAndUsageDto } from 'src/app/shared/generated/model/parc
 export class ParcelLedgerBulkCreateComponent implements OnInit {
   @ViewChild('parcelSelectGrid') parcelSelectGrid: AgGridAngular;
 
-  private watchUserChangeSubscription: any;
+  
   private gridApi;
   private columnApi;
   public currentUser: UserDto;
@@ -62,7 +62,7 @@ export class ParcelLedgerBulkCreateComponent implements OnInit {
     this.model = new ParcelLedgerCreateDto();
     this.model.ParcelNumbers = [];
 
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe((currentUser) => {
+    this.authenticationService.getCurrentUser().subscribe((currentUser) => {
       this.currentUser = currentUser;
 
       forkJoin(
@@ -80,8 +80,8 @@ export class ParcelLedgerBulkCreateComponent implements OnInit {
   }
 
   ngOnDestroy() {
-    this.watchUserChangeSubscription.unsubscribe();
-    this.authenticationService.dispose();
+    
+    
     this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/parcel-ledger-create-from-spreadsheet/parcel-ledger-create-from-spreadsheet.component.ts
+++ b/Source/Rio.Web/src/app/pages/parcel-ledger-create-from-spreadsheet/parcel-ledger-create-from-spreadsheet.component.ts
@@ -21,7 +21,7 @@ import { NgbDateAdapter, NgbDateNativeAdapter } from '@ng-bootstrap/ng-bootstrap
 })
 export class ParcelLedgerCreateFromSpreadsheetComponent implements OnInit {
 
-  private watchUserChangeSubscription: any;
+  
   private currentUser: UserDto;
   public richTextTypeID = CustomRichTextType.ParcelLedgerCreateFromSpreadsheet;
   public waterTypes: WaterTypeDto[];
@@ -44,7 +44,7 @@ export class ParcelLedgerCreateFromSpreadsheetComponent implements OnInit {
   ) { }
 
   ngOnInit(): void {
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe((currentUser) => {
+    this.authenticationService.getCurrentUser().subscribe((currentUser) => {
       this.currentUser = currentUser;
 
       this.waterTypeService.getWaterTypes().subscribe(waterTypes => {
@@ -54,8 +54,8 @@ export class ParcelLedgerCreateFromSpreadsheetComponent implements OnInit {
   }
 
   ngOnDestroy() {
-    this.watchUserChangeSubscription.unsubscribe();
-    this.authenticationService.dispose();
+    
+    
     this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/parcel-ledger-create/parcel-ledger-create.component.ts
+++ b/Source/Rio.Web/src/app/pages/parcel-ledger-create/parcel-ledger-create.component.ts
@@ -25,7 +25,7 @@ import { WaterTypeDto } from 'src/app/shared/generated/model/water-type-dto';
 })
 export class ParcelLedgerCreateComponent implements OnInit {
 
-  private watchUserChangeSubscription: any;
+  
   public currentUser: UserDto;
   public parcelFromRoute: ParcelDto;
   public waterTypes: WaterTypeDto[];
@@ -51,7 +51,7 @@ export class ParcelLedgerCreateComponent implements OnInit {
   ngOnInit(): void {
     this.model = new ParcelLedgerCreateDto();
     
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe((currentUser) => {
+    this.authenticationService.getCurrentUser().subscribe((currentUser) => {
       this.currentUser = currentUser;
 
       const id = this.route.snapshot.paramMap.get("id");
@@ -70,8 +70,8 @@ export class ParcelLedgerCreateComponent implements OnInit {
   }
 
   ngOnDestroy() {
-    this.watchUserChangeSubscription.unsubscribe();
-    this.authenticationService.dispose();
+    
+    
     this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/parcel-list-inactive/parcel-list-inactive.component.ts
+++ b/Source/Rio.Web/src/app/pages/parcel-list-inactive/parcel-list-inactive.component.ts
@@ -22,7 +22,7 @@ export class ParcelListInactiveComponent implements OnInit, OnDestroy {
 
   public richTextTypeID: number = CustomRichTextType.InactiveParcelList;
 
-  private watchUserChangeSubscription: any;
+  
   private currentUser: UserDto;
 
   public waterYears: Array<WaterYearDto>;
@@ -60,7 +60,7 @@ export class ParcelListInactiveComponent implements OnInit, OnDestroy {
     private datePipe: DatePipe) { }
 
   ngOnInit() {
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
 
       let _datePipe = this.datePipe;
       this.columnDefs = [
@@ -124,7 +124,7 @@ export class ParcelListInactiveComponent implements OnInit, OnDestroy {
 
       this.gridOptions = <GridOptions>{};
       this.currentUser = currentUser;
-      this.parcelsGrid.api.showLoadingOverlay();
+      this.parcelsGrid?.api.showLoadingOverlay();
 
       this.parcelService.getInactiveParcels().subscribe((parcels) => {
         this.rowData = parcels;
@@ -141,8 +141,8 @@ export class ParcelListInactiveComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.watchUserChangeSubscription.unsubscribe();
-    this.authenticationService.dispose();
+    
+    
     this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/parcel-list/parcel-list.component.ts
+++ b/Source/Rio.Web/src/app/pages/parcel-list/parcel-list.component.ts
@@ -25,7 +25,7 @@ export class ParcelListComponent implements OnInit, OnDestroy {
 
   public richTextTypeID: number = CustomRichTextType.ParcelList;
 
-  private watchUserChangeSubscription: any;
+  
   private currentUser: UserDto;
 
   public waterYears: Array<WaterYearDto>;
@@ -64,9 +64,7 @@ export class ParcelListComponent implements OnInit, OnDestroy {
     private decimalPipe: DecimalPipe) { }
 
   ngOnInit() {
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
-
-
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       let _decimalPipe = this.decimalPipe;
       this.columnDefs = [
         {
@@ -118,7 +116,7 @@ export class ParcelListComponent implements OnInit, OnDestroy {
 
       this.gridOptions = <GridOptions>{};
       this.currentUser = currentUser;
-      this.parcelsGrid.api.showLoadingOverlay();
+      this.parcelsGrid?.api.showLoadingOverlay();
       forkJoin([this.waterYearService.getDefaultWaterYearToDisplay(),
         this.waterTypeService.getWaterTypes()
       ]).subscribe(([defaultYear, waterTypes]) => {
@@ -166,8 +164,8 @@ export class ParcelListComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.watchUserChangeSubscription.unsubscribe();
-    this.authenticationService.dispose();
+    
+    
     this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/parcel-update-layer/parcel-update-layer.component.ts
+++ b/Source/Rio.Web/src/app/pages/parcel-update-layer/parcel-update-layer.component.ts
@@ -26,7 +26,7 @@ import { AlertService } from 'src/app/shared/services/alert.service';
 export class ParcelUpdateLayerComponent implements OnInit {
 
   @ViewChildren('fileInput') public fileInput: QueryList<any>;
-  private watchUserChangeSubscription: any;
+  
   public modalReference: NgbModalRef;
   public richTextTypeID: number = CustomRichTextType.ParcelUpdateLayer;
 
@@ -69,7 +69,7 @@ export class ParcelUpdateLayerComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       forkJoin([
       this.parcelService.getParcelGDBCommonMappingToParcelStagingColumn(),
       this.waterYearService.getWaterYearForCurrentYearAndVariableYearsBack(1)]).subscribe(([model, waterYears]) => {
@@ -97,8 +97,8 @@ export class ParcelUpdateLayerComponent implements OnInit {
   }
 
   ngOnDestroy() {
-    this.watchUserChangeSubscription.unsubscribe();
-    this.authenticationService.dispose();
+    
+    
     this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/posting-delete/posting-delete.component.ts
+++ b/Source/Rio.Web/src/app/pages/posting-delete/posting-delete.component.ts
@@ -17,7 +17,7 @@ import { UserDto } from 'src/app/shared/generated/model/user-dto';
   styleUrls: ['./posting-delete.component.scss']
 })
 export class PostingDeleteComponent implements OnInit, OnDestroy {
-  private watchUserChangeSubscription: any;
+  
   private currentUser: UserDto;
 
   public posting: PostingDto;
@@ -38,7 +38,7 @@ export class PostingDeleteComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-      this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+      this.authenticationService.getCurrentUser().subscribe(currentUser => {
           this.currentUser = currentUser;
           const postingID = parseInt(this.route.snapshot.paramMap.get("postingID"));
           if (postingID) {
@@ -57,8 +57,8 @@ export class PostingDeleteComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-      this.watchUserChangeSubscription.unsubscribe();
-      this.authenticationService.dispose();
+      
+      
       this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/posting-detail/posting-detail.component.ts
+++ b/Source/Rio.Web/src/app/pages/posting-detail/posting-detail.component.ts
@@ -23,7 +23,7 @@ import { UserDto } from 'src/app/shared/generated/model/user-dto';
     styleUrls: ['./posting-detail.component.scss']
 })
 export class PostingDetailComponent implements OnInit, OnDestroy {
-    private watchUserChangeSubscription: any;
+    
     private currentUser: UserDto;
 
     public posting: PostingDto;
@@ -58,7 +58,7 @@ export class PostingDetailComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit() {
-        this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+        this.authenticationService.getCurrentUser().subscribe(currentUser => {
             this.currentUser = currentUser;
             this.currentUserAccounts = this.authenticationService.getAvailableAccounts();
             const postingID = parseInt(this.route.snapshot.paramMap.get("postingID"));
@@ -78,8 +78,8 @@ export class PostingDetailComponent implements OnInit, OnDestroy {
     }
 
     ngOnDestroy() {
-        this.watchUserChangeSubscription.unsubscribe();
-        this.authenticationService.dispose();
+        
+        
         this.cdr.detach();
     }
 

--- a/Source/Rio.Web/src/app/pages/posting-list/posting-list.component.ts
+++ b/Source/Rio.Web/src/app/pages/posting-list/posting-list.component.ts
@@ -17,7 +17,7 @@ import { UserDto } from 'src/app/shared/generated/model/user-dto';
 export class PostingListComponent implements OnInit, OnDestroy {
   @ViewChild('postingsGrid') postingsGrid: AgGridAngular;
 
-  private watchUserChangeSubscription: any;
+  
   private currentUser: UserDto;
 
   descriptionMaxLength: number = 300;
@@ -29,10 +29,10 @@ export class PostingListComponent implements OnInit, OnDestroy {
   constructor(private cdr: ChangeDetectorRef, private authenticationService: AuthenticationService, private postingService: PostingService, private datePipe: DatePipe, private currencyPipe: CurrencyPipe, private decimalPipe: DecimalPipe) { }
 
   ngOnInit() {
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       this.postingTypeFilter = 0;
       this.currentUser = currentUser;
-      this.postingsGrid.api.showLoadingOverlay();
+      this.postingsGrid?.api.showLoadingOverlay();
       this.postingService.getPostings().subscribe(result => {
         this.postings = result;
         this.postingsGrid.api.hideOverlay();
@@ -102,8 +102,8 @@ export class PostingListComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.watchUserChangeSubscription.unsubscribe();
-    this.authenticationService.dispose();
+    
+    
     this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/posting-new/posting-new.component.ts
+++ b/Source/Rio.Web/src/app/pages/posting-new/posting-new.component.ts
@@ -18,7 +18,7 @@ import { UserDto } from 'src/app/shared/generated/model/user-dto';
   styleUrls: ['./posting-new.component.scss']
 })
 export class PostingNewComponent implements OnInit, OnDestroy {
-  private watchUserChangeSubscription: any;
+  
   private currentUser: UserDto;
 
   public postingTypes: Array<PostingTypeDto>;
@@ -38,7 +38,7 @@ export class PostingNewComponent implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit(): void {
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       this.currentUser = currentUser;
       this.currentUserAccounts = this.authenticationService.getAvailableAccounts();
       if (this.currentUserAccounts?.length == 1) {
@@ -52,8 +52,8 @@ export class PostingNewComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.watchUserChangeSubscription.unsubscribe();
-    this.authenticationService.dispose();
+    
+    
     this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/register-transfer/register-transfer.component.ts
+++ b/Source/Rio.Web/src/app/pages/register-transfer/register-transfer.component.ts
@@ -24,7 +24,7 @@ import { WaterTransferRegistrationUpsertDto } from 'src/app/shared/generated/mod
   styleUrls: ['./register-transfer.component.scss']
 })
 export class RegisterTransferComponent implements OnInit, OnDestroy {
-  private watchUserChangeSubscription: any;
+  
   private currentUser: UserDto;
   public waterTransfer: WaterTransferDetailedDto;
   public isRegisteringTransfer: boolean = false;
@@ -57,7 +57,7 @@ export class RegisterTransferComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       this.currentUser = currentUser;
       this.currentUserAccounts = this.authenticationService.getAvailableAccounts();
       const waterTransferID = parseInt(this.route.snapshot.paramMap.get("waterTransferID"));
@@ -74,8 +74,8 @@ export class RegisterTransferComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.watchUserChangeSubscription.unsubscribe();
-    this.authenticationService.dispose();
+    
+    
     this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/trade-detail/trade-detail.component.ts
+++ b/Source/Rio.Web/src/app/pages/trade-detail/trade-detail.component.ts
@@ -28,7 +28,7 @@ import { WaterTransferRegistrationSimpleDto } from 'src/app/shared/generated/mod
   styleUrls: ['./trade-detail.component.scss']
 })
 export class TradeDetailComponent implements OnInit, OnDestroy {
-  private watchUserChangeSubscription: any;
+  
   private currentUser: UserDto;
 
   public trade: TradeDto;
@@ -69,7 +69,7 @@ export class TradeDetailComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       this.currentUser = currentUser;
       this.currentUserAccounts = this.authenticationService.getAvailableAccounts();
       const tradeNumber = this.route.snapshot.paramMap.get("tradeNumber");
@@ -97,8 +97,8 @@ export class TradeDetailComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.watchUserChangeSubscription.unsubscribe();
-    this.authenticationService.dispose();
+    
+    
     this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/user-detail/user-detail.component.ts
+++ b/Source/Rio.Web/src/app/pages/user-detail/user-detail.component.ts
@@ -15,7 +15,7 @@ import { UserDto } from 'src/app/shared/generated/model/user-dto';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class UserDetailComponent implements OnInit, OnDestroy {
-    private watchUserChangeSubscription: any;
+    
     private currentUser: UserDto;
 
     public user: UserDto;
@@ -35,7 +35,7 @@ export class UserDetailComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit() {
-        this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+        this.authenticationService.getCurrentUser().subscribe(currentUser => {
             this.currentUser = currentUser;
             const id = parseInt(this.route.snapshot.paramMap.get("id"));
             if (id) {
@@ -55,8 +55,8 @@ export class UserDetailComponent implements OnInit, OnDestroy {
     }
 
     ngOnDestroy() {
-        this.watchUserChangeSubscription.unsubscribe();
-        this.authenticationService.dispose();
+        
+        
         this.cdr.detach();
     }
 

--- a/Source/Rio.Web/src/app/pages/user-edit-accounts/user-edit-accounts.component.ts
+++ b/Source/Rio.Web/src/app/pages/user-edit-accounts/user-edit-accounts.component.ts
@@ -51,7 +51,7 @@ export class UserEditAccountsComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.allAccounts = new Array<AccountDto>();
-    this.watchAccountChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.watchAccountChangeSubscription = this.authenticationService.getCurrentUser().subscribe(currentUser => {
       this.currentUser = currentUser;
 
       this.userID = parseInt(this.route.snapshot.paramMap.get("id"));
@@ -78,7 +78,7 @@ export class UserEditAccountsComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.watchAccountChangeSubscription.unsubscribe();
-    this.authenticationService.dispose();
+    
     this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/user-edit/user-edit.component.ts
+++ b/Source/Rio.Web/src/app/pages/user-edit/user-edit.component.ts
@@ -19,7 +19,7 @@ import { UserUpsertDto } from 'src/app/shared/generated/model/user-upsert-dto';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class UserEditComponent implements OnInit, OnDestroy {
-  private watchUserChangeSubscription: any;
+  
   private currentUser: UserDto;
 
   public userID: number;
@@ -40,7 +40,7 @@ export class UserEditComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       this.currentUser = currentUser;
 
       if (!this.authenticationService.isUserAnAdministrator(this.currentUser)) {
@@ -77,8 +77,8 @@ export class UserEditComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.watchUserChangeSubscription.unsubscribe();
-    this.authenticationService.dispose();
+    
+    
     this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/user-invite/user-invite.component.ts
+++ b/Source/Rio.Web/src/app/pages/user-invite/user-invite.component.ts
@@ -21,7 +21,7 @@ import { UserInviteDto } from 'src/app/shared/generated/model/user-invite-dto';
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class UserInviteComponent implements OnInit, OnDestroy {
-    private watchUserChangeSubscription: any;
+    
     private currentUser: UserDto;
 
     public roles: Array<RoleDto>;
@@ -33,7 +33,7 @@ export class UserInviteComponent implements OnInit, OnDestroy {
         private router: Router, private userService: UserService, private roleService: RoleService, private authenticationService: AuthenticationService, private alertService: AlertService) { }
 
     ngOnInit(): void {
-        this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+        this.authenticationService.getCurrentUser().subscribe(currentUser => {
             this.currentUser = currentUser;
             this.roleService.getRoles().subscribe(result => {
                 this.roles = result;
@@ -64,8 +64,8 @@ export class UserInviteComponent implements OnInit, OnDestroy {
     }
 
     ngOnDestroy() {
-        this.watchUserChangeSubscription.unsubscribe();
-        this.authenticationService.dispose();
+        
+        
         this.cdr.detach();
     }
 

--- a/Source/Rio.Web/src/app/pages/user-list/user-list.component.ts
+++ b/Source/Rio.Web/src/app/pages/user-list/user-list.component.ts
@@ -22,7 +22,7 @@ export class UserListComponent implements OnInit, OnDestroy {
   @ViewChild('usersGrid') usersGrid: AgGridAngular;
   @ViewChild('unassignedUsersGrid') unassignedUsersGrid: AgGridAngular;
 
-  private watchUserChangeSubscription: any;
+  
   private currentUser: UserDto;
 
   public rowData = [];
@@ -35,9 +35,9 @@ export class UserListComponent implements OnInit, OnDestroy {
   constructor(private cdr: ChangeDetectorRef, private authenticationService: AuthenticationService, private utilityFunctionsService: UtilityFunctionsService, private userService: UserService, private decimalPipe: DecimalPipe) { }
 
   ngOnInit() {
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       this.currentUser = currentUser;
-      this.usersGrid.api.showLoadingOverlay();
+      this.usersGrid?.api.showLoadingOverlay();
       this.userService.getUsers().subscribe(users => {
         this.rowData = users.filter(x => x.RoleID !== RoleEnum.Disabled);
         this.users = users;
@@ -129,8 +129,8 @@ export class UserListComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.watchUserChangeSubscription.unsubscribe();
-    this.authenticationService.dispose();
+    
+    
     this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/water-accounts-add/water-accounts-add.component.ts
+++ b/Source/Rio.Web/src/app/pages/water-accounts-add/water-accounts-add.component.ts
@@ -21,7 +21,7 @@ import { environment } from 'src/environments/environment';
 })
 export class WaterAccountsAddComponent implements OnInit {
 
-  private watchUserChangeSubscription: any;
+  
   public currentUser: UserDto;
 
   public verificationKeyToSearchFor: string;
@@ -53,7 +53,7 @@ export class WaterAccountsAddComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       this.currentUser = currentUser;
       
       this.userService.listAccountsByUserID(this.currentUser.UserID).subscribe(userAccounts => {
@@ -63,8 +63,8 @@ export class WaterAccountsAddComponent implements OnInit {
   }
 
   ngOnDestroy() {
-    this.watchUserChangeSubscription.unsubscribe();
-    this.authenticationService.dispose();
+    
+    
     this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/water-accounts-invite/water-accounts-invite.component.ts
+++ b/Source/Rio.Web/src/app/pages/water-accounts-invite/water-accounts-invite.component.ts
@@ -19,7 +19,7 @@ import { environment } from 'src/environments/environment';
 export class WaterAccountsInviteComponent implements OnInit {
   public introRichText: number = CustomRichTextType.WaterAccountsInvite;
 
-  private watchUserChangeSubscription: any;
+  
   private currentUser: UserDto;
 
   public model: UserPartnerInviteDto;
@@ -38,7 +38,7 @@ export class WaterAccountsInviteComponent implements OnInit {
 
   ngOnInit(): void {
     this.model = new UserPartnerInviteDto();
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       this.currentUser = currentUser;
       this.loadingAccounts = true;
       this.userService.listAccountsByUserID(currentUser.UserID).subscribe(accounts => {
@@ -49,8 +49,8 @@ export class WaterAccountsInviteComponent implements OnInit {
   }
 
   ngOnDestroy() {
-    this.watchUserChangeSubscription.unsubscribe();
-    this.authenticationService.dispose();
+    
+    
     this.cdr.detach();
   }
 

--- a/Source/Rio.Web/src/app/pages/water-accounts-list/water-accounts-list.component.ts
+++ b/Source/Rio.Web/src/app/pages/water-accounts-list/water-accounts-list.component.ts
@@ -16,7 +16,7 @@ import { UserDto } from 'src/app/shared/generated/model/user-dto';
   styleUrls: ['./water-accounts-list.component.scss']
 })
 export class WaterAccountsListComponent implements OnInit {
-  public watchUserChangeSubscription: any;
+  
   public currentUser: UserDto;
   public currentPage: number =  1;
 
@@ -35,7 +35,7 @@ export class WaterAccountsListComponent implements OnInit {
     ) { }
 
   ngOnInit(): void {
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       this.currentUser = currentUser;
       this.loadingAccounts = true;
       this.userService.listAccountsIncludeParcelsByUserID(this.currentUser.UserID).subscribe(userAccounts => {

--- a/Source/Rio.Web/src/app/pages/water-type-edit/water-type-edit.component.ts
+++ b/Source/Rio.Web/src/app/pages/water-type-edit/water-type-edit.component.ts
@@ -36,13 +36,13 @@ export class WaterTypeEditComponent implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit(): void {
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       this.resetWaterTypes();
     })
   }
 
   ngOnDestroy(): void {
-    this.watchUserChangeSubscription.unsubscribe();
+    
   }
 
   resetWaterTypes(): void {

--- a/Source/Rio.Web/src/app/services/authentication.service.ts
+++ b/Source/Rio.Web/src/app/services/authentication.service.ts
@@ -117,7 +117,7 @@ export class AuthenticationService {
     this.updateUser(user);
   }
 
-  public getCurrentUser(): Observable<UserDetailedDto> {
+  public getCurrentUser(): Observable<UserDto> {
     return race(
       new Observable(subscriber => {
         if (this.currentUser) {

--- a/Source/Rio.Web/src/app/services/authentication.service.ts
+++ b/Source/Rio.Web/src/app/services/authentication.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
 import { OAuthService } from 'angular-oauth2-oidc';
 import { UserService } from './user/user.service';
-import { Subject } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { Observable, race, Subject } from 'rxjs';
+import { filter, first } from 'rxjs/operators';
 import { CookieStorageService } from '../shared/services/cookies/cookie-storage.service';
 import { Router, NavigationEnd, NavigationStart } from '@angular/router';
 import { RoleEnum } from '../shared/models/enums/role.enum';
@@ -13,6 +13,7 @@ import { environment } from 'src/environments/environment';
 import { AccountSimpleDto } from '../shared/generated/model/account-simple-dto';
 import { UserCreateDto } from '../shared/generated/model/user-create-dto';
 import { UserDto } from '../shared/generated/model/user-dto';
+import { UserDetailedDto } from '../shared/generated/model/user-detailed-dto';
 
 @Injectable({
   providedIn: 'root'
@@ -20,10 +21,8 @@ import { UserDto } from '../shared/generated/model/user-dto';
 export class AuthenticationService {
   private currentUser: UserDto;
 
-  private getUserObservable: any;
-
   private _currentUserSetSubject = new Subject<UserDto>();
-  public currentUserSetObservable = this._currentUserSetSubject.asObservable();
+  private currentUserSetObservable = this._currentUserSetSubject.asObservable();
 
 
   constructor(private router: Router,
@@ -31,62 +30,70 @@ export class AuthenticationService {
     private cookieStorageService: CookieStorageService,
     private userService: UserService,
     private alertService: AlertService) {
-    this.router.events
-      .pipe(filter(e => e instanceof NavigationEnd))
-      .subscribe((e: NavigationEnd) => {
-        if (this.isAuthenticated()) {
-          this.getGlobalIDFromClaimsAndAttemptToSetUserObservableAndCreateUserIfNecessary();
-        } else {
-          this.currentUser = null;
-          this._currentUserSetSubject.next(null);
-        }
-      });
+    this.oauthService.events.subscribe(_ => {
+      this.checkAuthentication();
+    });
 
-    // check for a currentUser at NavigationStart so that authorization-based guards can work with promises.
-    this.router.events
-      .pipe(filter(e => e instanceof NavigationStart))
-      .subscribe((e: NavigationStart) => {
-        this.checkAuthentication();
-      })
+    this.oauthService.events
+      .pipe(filter(e => ['token_received'].includes(e.type)))
+      .subscribe(e => this.oauthService.loadUserProfile());
+
+    this.oauthService.events
+      .pipe(filter(e => ['token_error'].includes(e.type)))
+      .subscribe(e => this.router.navigateByUrl("/"));
+
+    this.oauthService.setupAutomaticSilentRefresh();
+  }
+
+  public initialLoginSequence() : Promise<void> {
+    return this.oauthService.loadDiscoveryDocument()
+      .then(() => this.oauthService.tryLogin())
+      .then(() => {
+        if (this.oauthService.hasValidAccessToken()) {
+          return Promise.resolve();
+        }
+        return this.oauthService.silentRefresh().then(() => Promise.resolve());
+      }).catch(() => {});
   }
 
   public checkAuthentication() {
     if (this.isAuthenticated() && !this.currentUser) {
       console.log("Authenticated but no user found...");
-      this.getGlobalIDFromClaimsAndAttemptToSetUserObservableAndCreateUserIfNecessary();
+      var claims = this.oauthService.getIdentityClaims();
+      this.getUser(claims);
     }
   }
 
-  public getGlobalIDFromClaimsAndAttemptToSetUserObservableAndCreateUserIfNecessary() {
-    var claims = this.oauthService.getIdentityClaims();
+  public getUser(claims:any) {
     var globalID = claims["sub"];
 
-    this.getUserObservable = this.userService.getUserFromGlobalID(globalID).subscribe(result => {
-      this.getUserCallback(result);
-    }, error => {
-      if (error.status !== 404) {
-        this.alertService.pushAlert(new Alert("There was an error logging into the application.", AlertContext.Danger));
-        this.router.navigate(['/']);
-      } else {
-        this.alertService.clearAlerts();
-        const newUser = new UserCreateDto({
-          FirstName: claims["given_name"],
-          LastName: claims["family_name"],
-          Email: claims["email"],
-          RoleID: RoleEnum.Unassigned,
-          LoginName: claims["login_name"],
-          UserGuid: claims["sub"],
-        });
-
-        this.userService.createNewUser(newUser).subscribe(user => {
-          this.getUserCallback(user);
-        })
-
-      }
-    });
+    this.userService.getUserFromGlobalID(globalID).subscribe(
+      result => { this.updateUser(result);},
+      error => { this.onGetUserError(error, claims) }
+    );
   }
 
-  private getUserCallback(user: UserDto) {
+  private onGetUserError(error: any, claims: any) {
+    if (error.status !== 404) {
+      this.alertService.pushAlert(new Alert("There was an error logging into the application.", AlertContext.Danger));
+      this.router.navigate(['/']);
+    } else {
+      this.alertService.clearAlerts();
+      const newUser = new UserCreateDto({
+        FirstName: claims["given_name"],
+        LastName: claims["family_name"],
+        Email: claims["email"],
+        LoginName: claims["login_name"],
+        UserGuid: claims["sub"],
+      });
+
+      this.userService.createNewUser(newUser).subscribe(user => {
+        this.updateUser(user);
+      })
+    }
+  }
+
+  private updateUser(user: UserDto) {
     this.currentUser = user;
 
     if (this.isUserRoleDisabled(this.currentUser)) {
@@ -107,23 +114,27 @@ export class AuthenticationService {
   }
 
   public refreshUserInfo(user: UserDto) {
-    this.getUserCallback(user);
+    this.updateUser(user);
   }
 
-  dispose() {
-    this.getUserObservable.unsubscribe();
+  public getCurrentUser(): Observable<UserDetailedDto> {
+    return race(
+      new Observable(subscriber => {
+        if (this.currentUser) {
+          subscriber.next(this.currentUser);
+          subscriber.complete();
+        }
+      }),
+      this.currentUserSetObservable.pipe(first())
+    );
   }
 
   public isAuthenticated(): boolean {
     return this.oauthService.hasValidAccessToken();
   }
 
-  public handleUnauthorized(): void {
-    this.forcedLogout();
-  }
-
-  public forcedLogout() {
-    sessionStorage["authRedirectUrl"] = window.location.href;
+  public forcedLogout(url: string) {
+    this.setAuthRedirectUrl(url);
     this.logout();
   }
 
@@ -242,5 +253,17 @@ export class AuthenticationService {
 
   public hasCurrentUserAcknowledgedDisclaimer(): boolean {
     return this.currentUser != null && this.currentUser.DisclaimerAcknowledgedDate != null;
+  }
+
+  public getAuthRedirectUrl() {
+    return sessionStorage["authRedirectUrl"];
+  }
+
+  public setAuthRedirectUrl(url: string) {
+    sessionStorage["authRedirectUrl"] = url;
+  }
+
+  public clearAuthRedirectUrl() {
+    this.setAuthRedirectUrl("");
   }
 }

--- a/Source/Rio.Web/src/app/shared/components/custom-rich-text/custom-rich-text.component.ts
+++ b/Source/Rio.Web/src/app/shared/components/custom-rich-text/custom-rich-text.component.ts
@@ -21,7 +21,7 @@ export class CustomRichTextComponent implements OnInit {
   public isLoading: boolean = true;
   public isEditing: boolean = false;
   public isEmptyContent: boolean = false;
-  public watchUserChangeSubscription: any;
+  
   public Editor = ClassicEditor;
   public editedContent: string;
   public editor;
@@ -39,7 +39,7 @@ export class CustomRichTextComponent implements OnInit {
     private sanitizer: DomSanitizer) { }
 
   ngOnInit() {
-    this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+    this.authenticationService.getCurrentUser().subscribe(currentUser => {
       this.currentUser = currentUser;
     });
     //window.Editor = this.Editor;

--- a/Source/Rio.Web/src/app/shared/components/header-nav/header-nav.component.ts
+++ b/Source/Rio.Web/src/app/shared/components/header-nav/header-nav.component.ts
@@ -21,7 +21,7 @@ import { UserDto } from '../../generated/model/user-dto';
 })
 
 export class HeaderNavComponent implements OnInit, OnDestroy {
-    private watchUserChangeSubscription: any;
+    
     private currentUser: UserDto;
     public trades: Array<TradeWithMostRecentOfferDto>;
 
@@ -44,7 +44,7 @@ export class HeaderNavComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit() {
-        this.watchUserChangeSubscription = this.authenticationService.currentUserSetObservable.subscribe(currentUser => {
+        this.authenticationService.getCurrentUser().subscribe(currentUser => {
             this.currentUser = currentUser;
 
             if (currentUser && this.authenticationService.isCurrentUserALandOwnerOrDemoUser() && environment.allowTrading) {
@@ -70,8 +70,8 @@ export class HeaderNavComponent implements OnInit, OnDestroy {
     }
 
     ngOnDestroy() {
-        this.watchUserChangeSubscription.unsubscribe();
-        this.authenticationService.dispose();
+        
+        
         this.cdr.detach();
     }
 

--- a/Source/Rio.Web/src/app/shared/components/header-nav/header-nav.component.ts
+++ b/Source/Rio.Web/src/app/shared/components/header-nav/header-nav.component.ts
@@ -109,6 +109,7 @@ export class HeaderNavComponent implements OnInit, OnDestroy {
     }
 
     public login(): void {
+        this.authenticationService.setAuthRedirectUrl(this.router.url);
         this.authenticationService.login();
     }
 

--- a/Source/Rio.Web/src/app/shared/guards/acknowledged-disclaimer-guard.ts
+++ b/Source/Rio.Web/src/app/shared/guards/acknowledged-disclaimer-guard.ts
@@ -29,7 +29,7 @@ export class AcknowledgedDisclaimerGuard implements CanActivate {
         }
       }
 
-      return this.authenticationService.currentUserSetObservable
+      return this.authenticationService.getCurrentUser()
       .pipe(
         map(x => {
           if (x.DisclaimerAcknowledgedDate != null) {

--- a/Source/Rio.Web/src/app/shared/guards/unauthenticated-access/assigned-not-disabled-guard.ts
+++ b/Source/Rio.Web/src/app/shared/guards/unauthenticated-access/assigned-not-disabled-guard.ts
@@ -22,7 +22,7 @@ export class AssignedNotDisabledGuard implements CanActivate {
       }
     }
 
-    return this.authenticationService.currentUserSetObservable
+    return this.authenticationService.getCurrentUser()
       .pipe(
         map(x => {
           if (!this.authenticationService.isUserUnassigned(x) && !this.authenticationService.isUserRoleDisabled(x)) {

--- a/Source/Rio.Web/src/app/shared/guards/unauthenticated-access/manager-only-guard.ts
+++ b/Source/Rio.Web/src/app/shared/guards/unauthenticated-access/manager-only-guard.ts
@@ -23,7 +23,7 @@ export class ManagerOnlyGuard implements CanActivate {
       }
     }
 
-    return this.authenticationService.currentUserSetObservable
+    return this.authenticationService.getCurrentUser()
       .pipe(
         map(x => {
           if (x.Role.RoleID == RoleEnum.Admin) {

--- a/Source/Rio.Web/src/app/shared/guards/unauthenticated-access/manager-or-demouser-only-guard.ts
+++ b/Source/Rio.Web/src/app/shared/guards/unauthenticated-access/manager-or-demouser-only-guard.ts
@@ -22,7 +22,7 @@ export class ManagerOrDemoUserOnlyGuard implements CanActivate {
       }
     }
 
-    return this.authenticationService.currentUserSetObservable
+    return this.authenticationService.getCurrentUser()
       .pipe(
         map(x => {
           if (this.authenticationService.isUserADemoUserOrAdministrator(x)) {

--- a/Source/Rio.Web/src/app/shared/guards/unauthenticated-access/unauthenticated-access.guard.ts
+++ b/Source/Rio.Web/src/app/shared/guards/unauthenticated-access/unauthenticated-access.guard.ts
@@ -13,11 +13,10 @@ export class UnauthenticatedAccessGuard implements CanActivate {
   }
 
   canActivate(next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> | Promise<boolean> | boolean {
-    const token = this.cookieStorageService.getItem('access_token');
-    if (token && this.authenticationService.isAuthenticated()) {
+    if (this.authenticationService.isAuthenticated()) {
       return true;
     } else {
-      sessionStorage["authRedirectUrl"] = state.url;
+      this.authenticationService.setAuthRedirectUrl(state.url);
       this.authenticationService.login()
       return false;
     }

--- a/Source/Rio.Web/src/app/shared/services/cookies/cookie-storage.service.ts
+++ b/Source/Rio.Web/src/app/shared/services/cookies/cookie-storage.service.ts
@@ -16,13 +16,11 @@ export class CookieStorageService extends OAuthStorage {
   }
 
   removeItem(key: string): void {
-    // passing in the path parameter that was explicitly set 
-    return this.cookieService.delete(key, '/');
+    return this.cookieService.delete(key);
   }
 
   removeAll(): void {
-    // passing in the path parameter that was explicitly set 
-    return this.cookieService.deleteAll('/');
+    return this.cookieService.deleteAll();
   }
 
   setItem(key: string, data: string): void {

--- a/Source/Rio.Web/src/app/shared/services/cookies/cookie-storage.service.ts
+++ b/Source/Rio.Web/src/app/shared/services/cookies/cookie-storage.service.ts
@@ -16,11 +16,11 @@ export class CookieStorageService extends OAuthStorage {
   }
 
   removeItem(key: string): void {
-    return this.cookieService.delete(key);
+    return this.cookieService.delete(key, '/');
   }
 
   removeAll(): void {
-    return this.cookieService.deleteAll();
+    return this.cookieService.deleteAll('/');
   }
 
   setItem(key: string, data: string): void {


### PR DESCRIPTION
This branch serves to mitigate (and hopefully eradicate) the random logout error occurring mostly across multiple tabs.

We need to listen to token_refresh_error otherwise we will in theory stay logged in until the user initiates a logout,  from what I can tell there is no other operation that occurs in our current setup that will trigger a message that we can accurately hook onto except token_refresh_error.

So, listen for token_refresh_error, but if we still have a valid access token then just don't worry about the logout. If our access token is invalid, log us out. If we don't have an access token at all, just navigate the user to the homepage.