### PR TITLE
Enable response compression (Brotli + Gzip Optimal)

### DIFF
--- a/Rio.API/Startup.cs
+++ b/Rio.API/Startup.cs
@@ -4,6 +4,7 @@ using IdentityServer4.AccessTokenValidation;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,7 +17,9 @@ using Rio.EFModels.Entities;
 using SendGrid.Extensions.DependencyInjection;
 using Serilog;
 using System;
+using System.IO.Compression;
 using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using Zybach.API.Logging;
@@ -53,6 +56,16 @@ namespace Rio.API
                         }
                     }
                 });
+
+            services.AddResponseCompression(options =>
+            {
+                options.EnableForHttps = true;
+                options.Providers.Add<BrotliCompressionProvider>();
+                options.Providers.Add<GzipCompressionProvider>();
+                options.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(new[] { "application/json" });
+            });
+            services.Configure<BrotliCompressionProviderOptions>(options => options.Level = CompressionLevel.Optimal);
+            services.Configure<GzipCompressionProviderOptions>(options => options.Level = CompressionLevel.Optimal);
 
             services.Configure<RioConfiguration>(Configuration);
             var rioConfiguration = Configuration.Get<RioConfiguration>();
@@ -162,6 +175,7 @@ namespace Rio.API
                 app.UseHsts();
             }
             app.UseHttpsRedirection();
+            app.UseResponseCompression();
 
             app.UseRouting();
             app.UseCors(policy =>


### PR DESCRIPTION
## Summary
- Adds `Microsoft.AspNetCore.ResponseCompression` to `Rio.API`
- Brotli + Gzip providers (browsers prefer Brotli; Gzip is the universal fallback)
- Compression level set to `Optimal` — small server CPU cost for ~30% smaller output vs `Fastest`

Cribbed from the same change on Qanat ([esassoc/qanat@753b0b7](https://github.com/esassoc/qanat/commit/753b0b70986667637b3c2776773496381599317b)), which measured ~10× smaller JSON payloads on the worst-case page. Production gains scale with network bandwidth savings on every endpoint with a non-trivial response and should also cut Azure egress costs.

## Test plan
- [ ] Smoke-test a heavy endpoint locally and confirm `Content-Encoding: br` (or `gzip`) on the response
- [ ] Verify swagger UI and health checks still load

🤖 Generated with [Claude Code](https://claude.com/claude-code)